### PR TITLE
Added support for tables schemas

### DIFF
--- a/Rebus.SqlServer.Tests/Assumptions/TestTableName.cs
+++ b/Rebus.SqlServer.Tests/Assumptions/TestTableName.cs
@@ -1,0 +1,48 @@
+﻿using NUnit.Framework;
+
+namespace Rebus.SqlServer.Tests.Assumptions
+{
+    [TestFixture]
+    public class TestTableName
+    {
+        [Test]
+        public void ParsesNameWithoutSchemaAssumingDboAsDefault()
+        {
+            var table = new TableName("TableName");
+
+            Assert.AreEqual(table.Name, "TableName");
+            Assert.AreEqual(table.Schema, "dbo");
+            Assert.AreEqual(table.QualifiedName, "[dbo].[TableName]");
+        }
+
+        [Test]
+        public void ParsesBracketsNameWithoutSchemaAssumingDboAsDefault()
+        {
+            var table = new TableName("[TableName]");
+
+            Assert.AreEqual(table.Name, "TableName");
+            Assert.AreEqual(table.Schema, "dbo");
+            Assert.AreEqual(table.QualifiedName, "[dbo].[TableName]");
+        }
+
+        [Test]
+        public void ParsesNameWithSchema()
+        {
+            var table = new TableName("schema.TableName");
+
+            Assert.AreEqual(table.Name, "TableName");
+            Assert.AreEqual(table.Schema, "schema");
+            Assert.AreEqual(table.QualifiedName, "[schema].[TableName]");
+        }
+
+        [Test]
+        public void ParsesBracketsNameWithSchema()
+        {
+            var table = new TableName("[schema].[TableName]");
+
+            Assert.AreEqual(table.Name, "TableName");
+            Assert.AreEqual(table.Schema, "schema");
+            Assert.AreEqual(table.QualifiedName, "[schema].[TableName]");
+        }
+    }
+}

--- a/Rebus.SqlServer.Tests/Integration/TestNumberOfSqlConnections.cs
+++ b/Rebus.SqlServer.Tests/Integration/TestNumberOfSqlConnections.cs
@@ -87,7 +87,7 @@ namespace Rebus.SqlServer.Tests.Integration
                     return _innerConnection.CreateCommand();
                 }
 
-                public IEnumerable<string> GetTableNames()
+                public IEnumerable<TableName> GetTableNames()
                 {
                     return _innerConnection.GetTableNames();
                 }
@@ -97,9 +97,9 @@ namespace Rebus.SqlServer.Tests.Integration
                     await _innerConnection.Complete();
                 }
 
-                public IEnumerable<DbColumn> GetColumns(string dataTableName)
+                public IEnumerable<DbColumn> GetColumns(string schema, string dataTableName)
                 {
-                    return _innerConnection.GetColumns(dataTableName);
+                    return _innerConnection.GetColumns(schema, dataTableName);
                 }
 
                 public void Dispose()

--- a/Rebus.SqlServer.Tests/Rebus.SqlServer.Tests.csproj
+++ b/Rebus.SqlServer.Tests/Rebus.SqlServer.Tests.csproj
@@ -65,6 +65,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Assumptions\TestSpWho.cs" />
+    <Compile Include="Assumptions\TestTableName.cs" />
     <Compile Include="Bugs\TestBugWhenSendingMessagesInParallel.cs" />
     <Compile Include="DataBus\SqlServerDataBusStorageFactory.cs" />
     <Compile Include="DataBus\SqlServerDataBusStorageTest.cs" />

--- a/Rebus.SqlServer.Tests/SqlTestHelper.cs
+++ b/Rebus.SqlServer.Tests/SqlTestHelper.cs
@@ -54,11 +54,12 @@ namespace Rebus.SqlServer.Tests
 
         public static void DropTable(string tableName)
         {
-            DropObject($"DROP TABLE [{tableName}]", connection =>
+            var table = new TableName(tableName);
+            DropObject($"DROP TABLE {table.QualifiedName}", connection =>
             {
                 var tableNames = connection.GetTableNames();
 
-                return tableNames.Contains(tableName, StringComparer.InvariantCultureIgnoreCase);
+                return tableNames.Contains(table);
             });
         }
 

--- a/Rebus.SqlServer/Rebus.SqlServer.csproj
+++ b/Rebus.SqlServer/Rebus.SqlServer.csproj
@@ -67,6 +67,7 @@
     <Compile Include="SqlServer\Sagas\SqlServerSagaSnapshotStorage.cs" />
     <Compile Include="SqlServer\Sagas\SqlServerSagaStorage.cs" />
     <Compile Include="SqlServer\Subscriptions\SqlServerSubscriptionStorage.cs" />
+    <Compile Include="SqlServer\TableName.cs" />
     <Compile Include="SqlServer\Timeouts\SqlServerTimeoutManager.cs" />
     <None Include="packages.config" />
     <None Include="Properties\AssemblyInfo.cs" />

--- a/Rebus.SqlServer/SqlServer/DbConnectionWrapper.cs
+++ b/Rebus.SqlServer/SqlServer/DbConnectionWrapper.cs
@@ -44,7 +44,7 @@ namespace Rebus.SqlServer
         /// <summary>
         /// Gets the names of all the tables in the current database for the current schema
         /// </summary>
-        public IEnumerable<string> GetTableNames()
+        public IEnumerable<TableName> GetTableNames()
         {
             try
             {
@@ -59,12 +59,12 @@ namespace Rebus.SqlServer
         /// <summary>
         /// Gets information about the columns in the table given by <paramref name="dataTableName"/>
         /// </summary>
-        public IEnumerable<DbColumn> GetColumns(string dataTableName)
+        public IEnumerable<DbColumn> GetColumns(string schema, string dataTableName)
         {
             try
             {
                 return _connection
-                    .GetColumns(dataTableName, _currentTransaction)
+                    .GetColumns(schema, dataTableName, _currentTransaction)
                     .Select(kvp => new DbColumn(kvp.Key, kvp.Value))
                     .ToList();
             }

--- a/Rebus.SqlServer/SqlServer/IDbConnection.cs
+++ b/Rebus.SqlServer/SqlServer/IDbConnection.cs
@@ -20,7 +20,7 @@ namespace Rebus.SqlServer
         /// <summary>
         /// Gets the names of all the tables in the current database for the current schema
         /// </summary>
-        IEnumerable<string> GetTableNames();
+        IEnumerable<TableName> GetTableNames();
         
         /// <summary>
         /// Marks that all work has been successfully done and the <see cref="SqlConnection"/> may have its transaction committed or whatever is natural to do at this time
@@ -28,9 +28,9 @@ namespace Rebus.SqlServer
         Task Complete();
 
         /// <summary>
-        /// Gets information about the columns in the table given by <paramref name="dataTableName"/>
+        /// Gets information about the columns in the table given by [<paramref name="schema"/>].[<paramref name="dataTableName"/>]
         /// </summary>
-        IEnumerable<DbColumn> GetColumns(string dataTableName);
+        IEnumerable<DbColumn> GetColumns(string schema, string dataTableName);
     }
 
     /// <summary>

--- a/Rebus.SqlServer/SqlServer/TableName.cs
+++ b/Rebus.SqlServer/SqlServer/TableName.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using System.Linq;
+
+namespace Rebus.SqlServer
+{
+    public class TableName: IEquatable<TableName>
+    {
+        public string Schema { get; }
+        public string Name { get; }
+
+        internal string QualifiedName => $"[{Schema}].[{Name}]";
+
+        public TableName(string schema, string tableName)
+        {
+            Schema = StripBrackets(schema);
+            Name = StripBrackets(tableName);
+        }
+
+        public TableName(string tableName)
+        {
+            if (tableName.Contains("."))
+            {
+                var splitted = tableName.Split(new[] {'.'}, StringSplitOptions.RemoveEmptyEntries);
+                var schema = splitted[0];
+                var name = string.Join(".", splitted.Skip(1));
+
+                Schema = StripBrackets(schema);
+                Name = StripBrackets(name);
+            }
+            else
+            {
+                Schema = "dbo";
+                Name = StripBrackets(tableName);
+            }
+        }
+
+        private string StripBrackets(string value)
+        {
+            if (value.StartsWith("["))
+            {
+                value = value.Substring(1);
+            }
+            if (value.EndsWith("]"))
+            {
+                value = value.Substring(0, value.Length - 1);
+            }
+
+            return value;
+        }
+
+        public bool Equals(TableName other)
+        {
+            if (other == null)
+                return false;
+
+            return
+                string.Equals(Schema, other.Schema, StringComparison.CurrentCultureIgnoreCase) &&
+                string.Equals(Name, other.Name, StringComparison.CurrentCultureIgnoreCase);
+        }
+
+        public override int GetHashCode()
+        {
+            return Schema.GetHashCode() + Name.GetHashCode();
+        }
+    }
+}


### PR DESCRIPTION
Support added by creating a TableName object which parses a string, stripping brackets, and stores the schema and table name.

When reading, the object has three properties: Schema (contains the schema), Name (contains the table name) and QualifiedName (concatenates schema and table name in [schema].[name] format).

Four tests were added to test the parse behavior.

It was also necessary to add checks before queries that creates something, because the schema might not exist. 

All tests passing.

![image](https://cloud.githubusercontent.com/assets/10968460/20234374/5bc4e666-a861-11e6-8752-b09091d580f6.png)



---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.

