### PR TITLE
Leased SQL Server Message Processing

### DIFF
--- a/Rebus.SqlServer/SqlServer/Transport/SqlServerLeaseTransport.cs
+++ b/Rebus.SqlServer/SqlServer/Transport/SqlServerLeaseTransport.cs
@@ -250,7 +250,7 @@ SET		leaseduntil =	CASE
 WHERE	id = @id
 ";
 					command.Parameters.Add("@id", SqlDbType.BigInt).Value = messageId;
-					command.Parameters.Add("@leaseintervalmilliseconds", SqlDbType.BigInt).Value = leaseIntervalMilliseconds;
+					command.Parameters.Add("@leaseintervalmilliseconds", SqlDbType.BigInt).Value = (object)leaseIntervalMilliseconds ?? DBNull.Value;
 					await command.ExecuteNonQueryAsync();
 				}
 

--- a/Rebus.SqlServer/SqlServer/Transport/SqlServerLeaseTransport.cs
+++ b/Rebus.SqlServer/SqlServer/Transport/SqlServerLeaseTransport.cs
@@ -142,7 +142,19 @@ OUTPUT	inserted.*";
 			return transportMessage;
 	    }
 
-		/// <summary>
+	    /// <summary>
+	    /// Provides an oppurtunity for derived implementations to also update the schema
+	    /// </summary>
+	    protected override string AdditionalSchenaModifications(IDbConnection connection) {
+			return $@"
+IF NOT EXISTS (SELECT 1 FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA = '{TableName.Schema}' AND TABLE_NAME = '{TableName.Name}' AND COLUMN_NAME = 'leaseduntil')
+BEGIN
+	ALTER TABLE {TableName.QualifiedName} ADD leaseduntil datetime2 null
+END
+";
+		}
+
+	    /// <summary>
 		/// Responsible for releasing the lease on message failure and removing the message on transaction commit
 		/// </summary>
 		/// <param name="context">Transaction context of the message processing</param>

--- a/Rebus.SqlServer/SqlServer/Transport/SqlServerLeaseTransport.cs
+++ b/Rebus.SqlServer/SqlServer/Transport/SqlServerLeaseTransport.cs
@@ -1,0 +1,286 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Data;
+using System.Data.SqlClient;
+using System.Threading;
+using System.Threading.Tasks;
+using Rebus.Logging;
+using Rebus.Messages;
+using Rebus.Threading;
+using Rebus.Transport;
+
+namespace Rebus.SqlServer.Transport
+{
+	/// <summary>
+	/// Similar to <seealso cref="SqlServerTransport"/> but does not maintain an active connection during message processing. Instead a "lease" is acquired for each message and only once "committed" is the message removed from the queue.
+	/// <remarks>Note: This also changes the semantics of sending. Sent messages are queued in memory and are not committed to memory until the sender has committed</remarks>
+	/// </summary>
+    public class SqlServerLeaseTransport : SqlServerTransport
+    {
+		/// <summary>
+		/// Key for storing the outbound message buffer when performing <seealso cref="Send"/>
+		/// </summary>
+	    public const string OutboundMessageBufferKey = "sql-server-transport-leased-outbound-message-buffer";
+
+		/// <summary>
+		/// If not specified the default time messages are leased for
+		/// </summary>
+		public static readonly TimeSpan DefaultLeaseTime = TimeSpan.FromMinutes(5);
+
+		/// <summary>
+		/// If not specified the amount of tolerance workers will allow a message which has already been leased
+		/// </summary>
+		public static readonly TimeSpan DefaultLeaseTolerance = TimeSpan.FromSeconds(30);
+
+		/// <summary>
+		/// If not specified the amount of time the workers will automatically renew leases for actively handled messages
+		/// </summary>
+		public static readonly TimeSpan DefaultLeaseAutomaticRenewal = TimeSpan.FromSeconds(150);
+
+	    private readonly long _leaseIntervalMilliseconds;
+	    private readonly long _leaseToleranceMilliseconds;
+	    private readonly bool _automaticLeaseRenewal;
+	    private readonly long _automaticLeaseRenewalIntervalMilliseconds;
+
+		/// <summary>
+		/// Constructor
+		/// </summary>
+	    public SqlServerLeaseTransport(
+			IDbConnectionProvider connectionProvider, 
+			string tableName, 
+			string inputQueueName, 
+			IRebusLoggerFactory rebusLoggerFactory, 
+			IAsyncTaskFactory asyncTaskFactory,
+			TimeSpan leaseInterval, 
+			TimeSpan? leaseTolerance,
+			TimeSpan? automaticLeaseRenewalInterval = null
+			) : base(connectionProvider, tableName, inputQueueName, rebusLoggerFactory, asyncTaskFactory)
+		{
+			_leaseIntervalMilliseconds = (long)Math.Ceiling(leaseInterval.TotalMilliseconds);
+			_leaseToleranceMilliseconds = (long)Math.Ceiling((leaseTolerance ?? TimeSpan.FromSeconds(15)).TotalMilliseconds);
+			if (automaticLeaseRenewalInterval.HasValue == false) {
+				_automaticLeaseRenewal = false;
+			} else {
+				_automaticLeaseRenewal = true;
+				_automaticLeaseRenewalIntervalMilliseconds = (long)Math.Ceiling(automaticLeaseRenewalInterval.Value.TotalMilliseconds);
+			}
+		}
+
+	    /// <summary>
+	    /// Sends the given transport message to the specified logical destination address by adding it to the messages table.
+	    /// </summary>
+	    public override Task Send(string destinationAddress, TransportMessage message, ITransactionContext context) {
+			ConcurrentQueue<AddressedTransportMessage> outboundMessageBuffer = GetOutboundMessageBuffer(context);
+			outboundMessageBuffer.Enqueue(
+				new AddressedTransportMessage() {
+					DestinationAddress = GetDestinationAddressToUse(destinationAddress, message),
+					Message = message
+				}
+			);
+
+			return Task.FromResult(0);
+	    }
+
+	    /// <summary>
+	    /// Handle retrieving a message from the queue, decoding it, and performing any transaction maintenance.
+	    /// </summary>
+	    /// <param name="context">Tranasction context the receive is operating on</param>
+	    /// <param name="cancellationToken">Token to abort processing</param>
+	    /// <returns>A <seealso cref="TransportMessage"/> or <c>null</c> if no message can be dequeued</returns>
+	    protected override async Task<TransportMessage> ReceiveInternal(ITransactionContext context, CancellationToken cancellationToken) {
+			TransportMessage transportMessage = null;
+
+			using (IDbConnection connection = await ConnectionProvider.GetConnection()) {
+				using (SqlCommand selectCommand = connection.CreateCommand()) {
+					selectCommand.CommandType = CommandType.Text;
+					selectCommand.CommandText = $@"
+;WITH TopCTE AS (
+	SELECT	TOP 1
+			[id],
+			[headers],
+			[body],
+			[leaseduntil]
+	FROM	{TableName.QualifiedName} M WITH (ROWLOCK, READPAST)
+	WHERE	M.[recipient] = @recipient
+	AND		M.[visible] < getdate()
+	AND		M.[expiration] > getdate()
+	AND		1 = CASE
+					WHEN M.[leaseduntil] is null then 1
+					WHEN DATEADD(ms, @leasetolerancemilliseconds, M.[leaseduntil]) < getdate() THEN 1
+					ELSE 0
+				END
+	ORDER
+	BY		[priority] ASC,
+			[id] ASC
+)
+UPDATE	TopCTE WITH (ROWLOCK)
+SET		leaseduntil = DATEADD(ms, @leasemilliseconds, getdate())
+OUTPUT	inserted.*";
+					selectCommand.Parameters.Add("@recipient", SqlDbType.NVarChar, RecipientColumnSize).Value = InputQueueName;
+					selectCommand.Parameters.Add("@leasemilliseconds", SqlDbType.BigInt).Value = _leaseIntervalMilliseconds;
+					selectCommand.Parameters.Add("@leasetolerancemilliseconds", SqlDbType.BigInt).Value = _leaseToleranceMilliseconds;
+
+					try {
+						using (SqlDataReader reader = await selectCommand.ExecuteReaderAsync(cancellationToken)) {
+							transportMessage = await ExtractTransportMessageFromReader(reader, cancellationToken);
+							if (transportMessage == null) {
+								return null;
+							}
+
+							Int64 messageId = (Int64)reader["id"];
+							ApplyTransactionSemantics(context, messageId);
+						}
+					} catch (Exception exception) when (cancellationToken.IsCancellationRequested) {
+						// ADO.NET does not throw the right exception when the task gets cancelled - therefore we need to do this:
+						throw new TaskCanceledException("Receive operation was cancelled", exception);
+					}
+				}
+
+				await connection.Complete();
+			}
+
+			return transportMessage;
+	    }
+
+		/// <summary>
+		/// Responsible for releasing the lease on message failure and removing the message on transaction commit
+		/// </summary>
+		/// <param name="context">Transaction context of the message processing</param>
+		/// <param name="messageId">Identifier of the message currently being processed</param>
+	    private void ApplyTransactionSemantics(ITransactionContext context, long messageId) {
+			AutomaticLeaseRenewer renewal = null;
+			if (_automaticLeaseRenewal == true) {
+				renewal = new AutomaticLeaseRenewer(TableName.QualifiedName, messageId, ConnectionProvider, _automaticLeaseRenewalIntervalMilliseconds, _leaseIntervalMilliseconds);
+			}
+
+			context.OnAborted(
+				async () => {
+					renewal?.Dispose();
+					await UpdateLease(ConnectionProvider, TableName.QualifiedName, messageId, null);
+				}
+			);
+			context.OnCommitted(
+				async () => {
+					renewal?.Dispose();
+
+					// Delete the message
+					using (IDbConnection deleteConnection = await ConnectionProvider.GetConnection()) {
+						using (SqlCommand deleteCommand = deleteConnection.CreateCommand()) {
+							deleteCommand.CommandType = CommandType.Text;
+							deleteCommand.CommandText = $@"
+DELETE
+FROM	{TableName.QualifiedName} WITH (ROWLOCK)
+WHERE	id = @id
+";
+							deleteCommand.Parameters.Add("@id", SqlDbType.BigInt).Value = messageId;
+							deleteCommand.ExecuteNonQuery();
+						}
+
+						await deleteConnection.Complete();
+					}
+				}
+			);
+	    }
+
+		/// <summary>
+		/// Gets the outbound message buffer for sending of messages
+		/// </summary>
+		/// <param name="context">Transaction context containing the message bufffer</param>
+	    private ConcurrentQueue<AddressedTransportMessage> GetOutboundMessageBuffer(ITransactionContext context)
+		{
+			return context.Items.GetOrAdd(OutboundMessageBufferKey, key => {
+				context.OnCommitted(
+					async () => {
+						object messageBufferRaw = null;
+						if (context.Items.TryGetValue(OutboundMessageBufferKey, out messageBufferRaw) == false) {
+							throw new Exception("Unable to extract message buffer from transaction context");
+						}
+
+						ConcurrentQueue<AddressedTransportMessage> messageBuffer = messageBufferRaw as ConcurrentQueue<AddressedTransportMessage>;
+						using (IDbConnection connection = await ConnectionProvider.GetConnection()) {
+							while (messageBuffer.IsEmpty == false) {
+								AddressedTransportMessage addressed = null;
+								if (messageBuffer.TryDequeue(out addressed) == false) {
+									break;
+								}
+
+								await InnerSend(addressed.DestinationAddress, addressed.Message, connection);
+							}
+
+							await connection.Complete();
+						}
+					}
+				);
+				return new ConcurrentQueue<AddressedTransportMessage>();
+			}
+			) as ConcurrentQueue<AddressedTransportMessage>;
+		}
+
+		/// <summary>
+		/// Updates a lease with a new leaseduntil value
+		/// </summary>
+		/// <param name="connectionProvider">Provider for obtaining a connection</param>
+		/// <param name="tableName">Name of the table the messages are stored in</param>
+		/// <param name="messageId">Identifier of the message whose lease is being updated</param>
+		/// <param name="leaseIntervalMilliseconds">New lease interval in milliseconds. If <c>null</c> the lease will be released</param>
+		/// <returns></returns>
+		private static async Task UpdateLease(IDbConnectionProvider connectionProvider, string tableName, long messageId, long? leaseIntervalMilliseconds)
+		{
+			using (IDbConnection connection = await connectionProvider.GetConnection()) {
+				using (SqlCommand command = connection.CreateCommand()) {
+					command.CommandType = CommandType.Text;
+					command.CommandText = $@"
+UPDATE	{tableName} WITH (ROWLOCK)
+SET		leaseduntil =	CASE
+							WHEN @leaseintervalmilliseconds IS NULL then NULL
+							ELSE dateadd(ms, @leaseintervalmilliseconds, getdate())
+						END
+WHERE	id = @id
+";
+					command.Parameters.Add("@id", SqlDbType.BigInt).Value = messageId;
+					command.Parameters.Add("@leaseintervalmilliseconds", SqlDbType.BigInt).Value = leaseIntervalMilliseconds;
+					await command.ExecuteNonQueryAsync();
+				}
+
+				await connection.Complete();
+			}
+		}
+
+		/// <summary>
+		/// Handles automatically renewing a lease for a given message
+		/// </summary>
+		private class AutomaticLeaseRenewer : IDisposable {
+			private readonly string _tableName;
+			private readonly long _messageId;
+			private readonly IDbConnectionProvider _connectionProvider;
+			private readonly long _leaseIntervalMilliseconds;
+			private readonly Timer _renewTimer;
+
+			public AutomaticLeaseRenewer(string tableName, long messageId, IDbConnectionProvider connectionProvider, long renewIntervalMilliseconds, long leaseIntervalMilliseconds)
+			{
+				_tableName = tableName;
+				_messageId = messageId;
+				_connectionProvider = connectionProvider;
+				_leaseIntervalMilliseconds = leaseIntervalMilliseconds;
+
+				_renewTimer = new Timer(RenewLease, null, TimeSpan.FromMilliseconds(renewIntervalMilliseconds), TimeSpan.FromMilliseconds(renewIntervalMilliseconds));
+			}
+
+			public void Dispose()
+			{
+				_renewTimer?.Change(TimeSpan.FromMilliseconds(-1), TimeSpan.FromMilliseconds(-1));
+				_renewTimer?.Dispose();
+			}
+
+			private async void RenewLease(object state)
+			{
+				await SqlServerLeaseTransport.UpdateLease(_connectionProvider, _tableName, _messageId, _leaseIntervalMilliseconds);
+			}
+		}
+
+		private class AddressedTransportMessage {
+		    public string DestinationAddress { get; set; }
+		    public TransportMessage Message { get; set; }
+	    }
+	}
+}

--- a/Rebus.SqlServer/SqlServer/Transport/SqlServerTransport.cs
+++ b/Rebus.SqlServer/SqlServer/Transport/SqlServerTransport.cs
@@ -46,10 +46,24 @@ namespace Rebus.SqlServer.Transport
         /// </summary>
         public static readonly TimeSpan DefaultExpiredMessagesCleanupInterval = TimeSpan.FromSeconds(20);
 
+		/// <summary>
+		/// Size, in the database, of the recipient column
+		/// </summary>
 	    protected const int RecipientColumnSize = 200;
 
+		/// <summary>
+		/// Connection provider for obtaining a database connection
+		/// </summary>
 		protected readonly IDbConnectionProvider ConnectionProvider;
+
+		/// <summary>
+		/// Name of the queue being processed by this transport
+		/// </summary>
 	    protected readonly string InputQueueName;
+
+		/// <summary>
+		/// Name of the table this transport is using for storage
+		/// </summary>
 	    protected readonly TableName TableName;
 		
         readonly AsyncBottleneck _bottleneck = new AsyncBottleneck(20);
@@ -304,6 +318,10 @@ IF NOT EXISTS (SELECT 1 FROM sys.indexes WHERE name = '{expirationIndexName}')
 		    return receivedTransportMessage;
 	    }
 
+		/// <summary>
+		/// Maps a <seealso cref="SqlDataReader"/> that's read a result from the message table into a <seealso cref="TransportMessage"/>
+		/// </summary>
+		/// <returns>A <seealso cref="TransportMessage"/> representing the row or <c>null</c> if no row was available</returns>
 	    protected static async Task<TransportMessage> ExtractTransportMessageFromReader(SqlDataReader reader, CancellationToken cancellationToken) {
 			if (await reader.ReadAsync(cancellationToken) == false) {
 				return null;

--- a/Rebus.SqlServer/SqlServer/Transport/SqlServerTransport.cs
+++ b/Rebus.SqlServer/SqlServer/Transport/SqlServerTransport.cs
@@ -46,12 +46,15 @@ namespace Rebus.SqlServer.Transport
         /// </summary>
         public static readonly TimeSpan DefaultExpiredMessagesCleanupInterval = TimeSpan.FromSeconds(20);
 
-        const int RecipientColumnSize = 200;
+	    protected const int RecipientColumnSize = 200;
 
+		protected readonly IDbConnectionProvider ConnectionProvider;
+	    protected readonly string InputQueueName;
+	    protected readonly TableName TableName;
+		
         readonly AsyncBottleneck _bottleneck = new AsyncBottleneck(20);
-        readonly IDbConnectionProvider _connectionProvider;
-        readonly TableName _tableName;
-        readonly string _inputQueueName;
+        
+        
         readonly ILog _log;
 
         readonly IAsyncTask _expiredMessagesCleanupTask;
@@ -68,9 +71,9 @@ namespace Rebus.SqlServer.Transport
             if (rebusLoggerFactory == null) throw new ArgumentNullException(nameof(rebusLoggerFactory));
             if (asyncTaskFactory == null) throw new ArgumentNullException(nameof(asyncTaskFactory));
 
-            _connectionProvider = connectionProvider;
-            _tableName = TableName.Parse(tableName);
-            _inputQueueName = inputQueueName;
+            ConnectionProvider = connectionProvider;
+            TableName = TableName.Parse(tableName);
+            InputQueueName = inputQueueName;
             _log = rebusLoggerFactory.GetLogger<SqlServerTransport>();
 
             ExpiredMessagesCleanupInterval = DefaultExpiredMessagesCleanupInterval;
@@ -83,7 +86,7 @@ namespace Rebus.SqlServer.Transport
         /// </summary>
         public void Initialize()
         {
-            if (_inputQueueName == null) return;
+            if (InputQueueName == null) return;
 
             _expiredMessagesCleanupTask.Start();
         }
@@ -96,7 +99,7 @@ namespace Rebus.SqlServer.Transport
         /// <summary>
         /// Gets the name that this SQL transport will use to query by when checking the messages table
         /// </summary>
-        public string Address => _inputQueueName;
+        public string Address => InputQueueName;
 
         /// <summary>
         /// The SQL transport doesn't really have queues, so this function does nothing
@@ -116,35 +119,35 @@ namespace Rebus.SqlServer.Transport
             }
             catch (SqlException exception)
             {
-                throw new RebusApplicationException(exception, $"Error attempting to initialize SQL transport schema with mesages table {_tableName.QualifiedName}");
+                throw new RebusApplicationException(exception, $"Error attempting to initialize SQL transport schema with mesages table {TableName.QualifiedName}");
             }
         }
 
         void CreateSchema()
         {
-            using (var connection = _connectionProvider.GetConnection().Result)
+            using (var connection = ConnectionProvider.GetConnection().Result)
             {
                 var tableNames = connection.GetTableNames();
                 
-                if (tableNames.Contains(_tableName))
+                if (tableNames.Contains(TableName))
                 {
-                    _log.Info("Database already contains a table named {tableName} - will not create anything", _tableName.QualifiedName);
+                    _log.Info("Database already contains a table named {tableName} - will not create anything", TableName.QualifiedName);
                     return;
                 }
 
-                _log.Info("Table {tableName} does not exist - it will be created now", _tableName.QualifiedName);
+                _log.Info("Table {tableName} does not exist - it will be created now", TableName.QualifiedName);
 
-                var receiveIndexName = $"IDX_RECEIVE_{_tableName.Schema}_{_tableName.Name}";
-                var expirationIndexName = $"IDX_EXPIRATION_{_tableName.Schema}_{_tableName.Name}";
+                var receiveIndexName = $"IDX_RECEIVE_{TableName.Schema}_{TableName.Name}";
+                var expirationIndexName = $"IDX_EXPIRATION_{TableName.Schema}_{TableName.Name}";
 
                 ExecuteCommands(connection, $@"
-IF NOT EXISTS (SELECT 1 FROM sys.schemas WHERE name = '{_tableName.Schema}')
-	EXEC('CREATE SCHEMA [{_tableName.Schema}]')
+IF NOT EXISTS (SELECT 1 FROM sys.schemas WHERE name = '{TableName.Schema}')
+	EXEC('CREATE SCHEMA [{TableName.Schema}]')
 
 ----
 
-IF NOT EXISTS (SELECT 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = '{_tableName.Schema}' AND TABLE_NAME = '{_tableName.Name}')
-    CREATE TABLE {_tableName.QualifiedName}
+IF NOT EXISTS (SELECT 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = '{TableName.Schema}' AND TABLE_NAME = '{TableName.Name}')
+    CREATE TABLE {TableName.QualifiedName}
     (
 	    [id] [bigint] IDENTITY(1,1) NOT NULL,
 	    [recipient] [nvarchar](200) NOT NULL,
@@ -153,7 +156,7 @@ IF NOT EXISTS (SELECT 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = '{_t
         [visible] [datetime2] NOT NULL,
 	    [headers] [varbinary](max) NOT NULL,
 	    [body] [varbinary](max) NOT NULL,
-        CONSTRAINT [PK_{_tableName.Schema}_{_tableName.Name}] PRIMARY KEY CLUSTERED 
+        CONSTRAINT [PK_{TableName.Schema}_{TableName.Name}] PRIMARY KEY CLUSTERED 
         (
 	        [recipient] ASC,
 	        [priority] ASC,
@@ -164,7 +167,7 @@ IF NOT EXISTS (SELECT 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = '{_t
 ----
 
 IF NOT EXISTS (SELECT 1 FROM sys.indexes WHERE name = '{receiveIndexName}')
-    CREATE NONCLUSTERED INDEX [{receiveIndexName}] ON {_tableName.QualifiedName}
+    CREATE NONCLUSTERED INDEX [{receiveIndexName}] ON {TableName.QualifiedName}
     (
 	    [recipient] ASC,
 	    [priority] ASC,
@@ -176,7 +179,7 @@ IF NOT EXISTS (SELECT 1 FROM sys.indexes WHERE name = '{receiveIndexName}')
 ----
 
 IF NOT EXISTS (SELECT 1 FROM sys.indexes WHERE name = '{expirationIndexName}')
-    CREATE NONCLUSTERED INDEX [{expirationIndexName}] ON {_tableName.QualifiedName}
+    CREATE NONCLUSTERED INDEX [{expirationIndexName}] ON {TableName.QualifiedName}
     (
         [expiration] ASC
     )
@@ -217,31 +220,38 @@ IF NOT EXISTS (SELECT 1 FROM sys.indexes WHERE name = '{expirationIndexName}')
         /// <summary>
         /// Sends the given transport message to the specified logical destination address by adding it to the messages table.
         /// </summary>
-        public async Task Send(string destinationAddress, TransportMessage message, ITransactionContext context)
+        public virtual async Task Send(string destinationAddress, TransportMessage message, ITransactionContext context)
         {
             var connection = await GetConnection(context);
 
-            var destinationAddressToUse = string.Equals(destinationAddress, MagicExternalTimeoutManagerAddress, StringComparison.CurrentCultureIgnoreCase)
-                ? GetDeferredRecipient(message)
-                : destinationAddress;
+            var destinationAddressToUse = GetDestinationAddressToUse(destinationAddress, message);
 
             await InnerSend(destinationAddressToUse, message, connection);
         }
 
-        /// <summary>
+	    /// <summary>
         /// Receives the next message by querying the messages table for a message with a recipient matching this transport's <see cref="Address"/>
         /// </summary>
         public async Task<TransportMessage> Receive(ITransactionContext context, CancellationToken cancellationToken)
         {
-            using (await _bottleneck.Enter(cancellationToken))
-            {
-                var connection = await GetConnection(context);
+            using (await _bottleneck.Enter(cancellationToken)) {
+	            return await ReceiveInternal(context, cancellationToken);
+            }
+        }
 
-                TransportMessage receivedTransportMessage;
+		/// <summary>
+		/// Handle retrieving a message from the queue, decoding it, and performing any transaction maintenance.
+		/// </summary>
+		/// <param name="context">Tranasction context the receive is operating on</param>
+		/// <param name="cancellationToken">Token to abort processing</param>
+		/// <returns>A <seealso cref="TransportMessage"/> or <c>null</c> if no message can be dequeued</returns>
+	    protected virtual async Task<TransportMessage> ReceiveInternal(ITransactionContext context, CancellationToken cancellationToken) {
+		    var connection = await GetConnection(context);
 
-                using (var selectCommand = connection.CreateCommand())
-                {
-                    selectCommand.CommandText = $@"
+		    TransportMessage receivedTransportMessage;
+
+		    using (var selectCommand = connection.CreateCommand()) {
+			    selectCommand.CommandText = $@"
 	SET NOCOUNT ON
 
 	;WITH TopCTE AS (
@@ -249,7 +259,7 @@ IF NOT EXISTS (SELECT 1 FROM sys.indexes WHERE name = '{expirationIndexName}')
 				[id],
 				[headers],
 				[body]
-		FROM	{_tableName.QualifiedName} M WITH (ROWLOCK, READPAST)
+		FROM	{TableName.QualifiedName} M WITH (ROWLOCK, READPAST)
 		WHERE	M.[recipient] = @recipient
 		AND		M.[visible] < getdate()
 		AND		M.[expiration] > getdate()
@@ -264,33 +274,46 @@ IF NOT EXISTS (SELECT 1 FROM sys.indexes WHERE name = '{expirationIndexName}')
 						
 						";
 
-                    selectCommand.Parameters.Add("recipient", SqlDbType.NVarChar, RecipientColumnSize).Value = _inputQueueName;
+			    selectCommand.Parameters.Add("recipient", SqlDbType.NVarChar, RecipientColumnSize).Value = InputQueueName;
 
-                    try
-                    {
-                        using (var reader = await selectCommand.ExecuteReaderAsync(cancellationToken))
-                        {
-                            if (!await reader.ReadAsync(cancellationToken)) return null;
+			    try {
+				    using (var reader = await selectCommand.ExecuteReaderAsync(cancellationToken)) {
+						receivedTransportMessage = await ExtractTransportMessageFromReader(reader, cancellationToken);
+				    }
+			    }
+			    catch (Exception exception) when (cancellationToken.IsCancellationRequested) {
+				    // ADO.NET does not throw the right exception when the task gets cancelled - therefore we need to do this:
+				    throw new TaskCanceledException("Receive operation was cancelled", exception);
+			    }
+		    }
 
-                            var headers = reader["headers"];
-                            var headersDictionary = HeaderSerializer.Deserialize((byte[]) headers);
-                            var body = (byte[]) reader["body"];
+		    return receivedTransportMessage;
+	    }
 
-                            receivedTransportMessage = new TransportMessage(headersDictionary, body);
-                        }
-                    }
-                    catch (Exception exception) when (cancellationToken.IsCancellationRequested)
-                    {
-                        // ADO.NET does not throw the right exception when the task gets cancelled - therefore we need to do this:
-                        throw new TaskCanceledException("Receive operation was cancelled", exception);
-                    }
-                }
+	    protected static async Task<TransportMessage> ExtractTransportMessageFromReader(SqlDataReader reader, CancellationToken cancellationToken) {
+			if (await reader.ReadAsync(cancellationToken) == false) {
+				return null;
+			}
 
-                return receivedTransportMessage;
-            }
-        }
+		    var headers = reader["headers"];
+		    var headersDictionary = HeaderSerializer.Deserialize((byte[]) headers);
+		    var body = (byte[]) reader["body"];
 
-        static string GetDeferredRecipient(TransportMessage message)
+		    return new TransportMessage(headersDictionary, body);
+	    }
+
+
+		/// <summary>
+		/// Gets the address a message will actually be sent to. Handles deferred messsages.
+		/// </summary>
+	    protected static string GetDestinationAddressToUse(string destinationAddress, TransportMessage message)
+		{
+			return string.Equals(destinationAddress, MagicExternalTimeoutManagerAddress, StringComparison.CurrentCultureIgnoreCase)
+				? GetDeferredRecipient(message)
+				: destinationAddress;
+		}
+
+		static string GetDeferredRecipient(TransportMessage message)
         {
             string destination;
 
@@ -302,12 +325,18 @@ IF NOT EXISTS (SELECT 1 FROM sys.indexes WHERE name = '{expirationIndexName}')
             throw new InvalidOperationException($"Attempted to defer message, but no '{Headers.DeferredRecipient}' header was on the message");
         }
 
-        async Task InnerSend(string destinationAddress, TransportMessage message, IDbConnection connection)
+		/// <summary>
+		/// Performs persistence of a message to the underlying table
+		/// </summary>
+		/// <param name="destinationAddress">Address the message will be sent to</param>
+		/// <param name="message">Message to be sent</param>
+		/// <param name="connection">Connection to use for writing to the database</param>
+        protected async Task InnerSend(string destinationAddress, TransportMessage message, IDbConnection connection)
         {
             using (var command = connection.CreateCommand())
             {
                 command.CommandText = $@"
-INSERT INTO {_tableName.QualifiedName}
+INSERT INTO {TableName.QualifiedName}
 (
     [recipient],
     [headers],
@@ -382,7 +411,7 @@ VALUES
 
             while (true)
             {
-                using (var connection = await _connectionProvider.GetConnection())
+                using (var connection = await ConnectionProvider.GetConnection())
                 {
                     int affectedRows;
 
@@ -391,13 +420,13 @@ VALUES
                         command.CommandText =
                             $@"
 ;with TopCTE as (
-	SELECT TOP 1 [id] FROM {_tableName.QualifiedName} WITH (ROWLOCK, READPAST)
+	SELECT TOP 1 [id] FROM {TableName.QualifiedName} WITH (ROWLOCK, READPAST)
 				WHERE [recipient] = @recipient 
 					AND [expiration] < getdate()
 )
 DELETE FROM TopCTE
 ";
-                        command.Parameters.Add("recipient", SqlDbType.NVarChar, RecipientColumnSize).Value = _inputQueueName;
+                        command.Parameters.Add("recipient", SqlDbType.NVarChar, RecipientColumnSize).Value = InputQueueName;
 
                         affectedRows = await command.ExecuteNonQueryAsync();
                     }
@@ -413,7 +442,7 @@ DELETE FROM TopCTE
             if (results > 0)
             {
                 _log.Info("Performed expired messages cleanup in {cleanupTimeSeconds} - {expiredMessageCount} expired messages with recipient {queueName} were deleted",
-                    stopwatch.Elapsed.TotalSeconds, results, _inputQueueName);
+                    stopwatch.Elapsed.TotalSeconds, results, InputQueueName);
             }
         }
 
@@ -438,7 +467,7 @@ DELETE FROM TopCTE
                 .GetOrAdd(CurrentConnectionKey,
                     async () =>
                     {
-                        var dbConnection = await _connectionProvider.GetConnection();
+                        var dbConnection = await ConnectionProvider.GetConnection();
                         context.OnCommitted(async () => await dbConnection.Complete());
                         context.OnDisposed(() =>
                         {

--- a/Rebus.SqlServer/SqlServer/Transport/SqlServerTransport.cs
+++ b/Rebus.SqlServer/SqlServer/Transport/SqlServerTransport.cs
@@ -123,6 +123,14 @@ namespace Rebus.SqlServer.Transport
             }
         }
 
+		/// <summary>
+		/// Provides an oppurtunity for derived implementations to also update the schema
+		/// </summary>
+		protected virtual string AdditionalSchenaModifications(IDbConnection connection)
+		{
+			return string.Empty;
+		}
+
         void CreateSchema()
         {
             using (var connection = ConnectionProvider.GetConnection().Result)
@@ -132,6 +140,10 @@ namespace Rebus.SqlServer.Transport
                 if (tableNames.Contains(TableName))
                 {
                     _log.Info("Database already contains a table named {tableName} - will not create anything", TableName.QualifiedName);
+					string additional = AdditionalSchenaModifications(connection);
+					ExecuteCommands(connection, additional);
+
+					connection.Complete().Wait();
                     return;
                 }
 
@@ -185,6 +197,8 @@ IF NOT EXISTS (SELECT 1 FROM sys.indexes WHERE name = '{expirationIndexName}')
     )
 
 ");
+
+				AdditionalSchenaModifications(connection);
 
                 connection.Complete().Wait();
             }


### PR DESCRIPTION
Introduces a new SQL Server transport - `SqlServerLeaseTransport` - which does not maintain any active connections to the database (or transactions) during message processing. Instead for sending of messages the messages are queued in memory until the `ITransactionContext` is committed at which stage the entire batch of messages is sent to the server. For receiving messages are leased, and optionally, automatically renewed. This prevents issues with long running message handlers causing transaction timeouts.

See https://github.com/rebus-org/Rebus.SqlServer/issues/13 for some background.

---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.
