### PR TITLE
Fix schema creation on a fresh database for SqlServerLeaseTransport

### DIFF
--- a/Rebus.SqlServer/SqlServer/Transport/SqlServerTransport.cs
+++ b/Rebus.SqlServer/SqlServer/Transport/SqlServerTransport.cs
@@ -150,11 +150,12 @@ namespace Rebus.SqlServer.Transport
             using (var connection = ConnectionProvider.GetConnection().Result)
             {
                 var tableNames = connection.GetTableNames();
-                
-                if (tableNames.Contains(TableName))
+				string additional = null;
+				
+				if (tableNames.Contains(TableName))
                 {
                     _log.Info("Database already contains a table named {tableName} - will not create anything", TableName.QualifiedName);
-					string additional = AdditionalSchenaModifications(connection);
+					additional = AdditionalSchenaModifications(connection);
 					ExecuteCommands(connection, additional);
 
 					connection.Complete().Wait();
@@ -212,9 +213,10 @@ IF NOT EXISTS (SELECT 1 FROM sys.indexes WHERE name = '{expirationIndexName}')
 
 ");
 
-				AdditionalSchenaModifications(connection);
+	            additional = AdditionalSchenaModifications(connection);
+	            ExecuteCommands(connection, additional);
 
-                connection.Complete().Wait();
+				connection.Complete().Wait();
             }
         }
 


### PR DESCRIPTION
This fixes #14 not creating a schema correctly for a completely fresh database

---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.
