### PR TITLE
Add a "leasedby" column

### DIFF
--- a/Rebus.SqlServer.Tests/SqlTestHelper.cs
+++ b/Rebus.SqlServer.Tests/SqlTestHelper.cs
@@ -210,7 +210,7 @@ namespace Rebus.SqlServer.Tests
         static string GetConnectionStringForDatabase(string databaseName)
         {
             return Environment.GetEnvironmentVariable("REBUS_SQLSERVER")
-                   ?? $"server=.\\SqlExpress; database={databaseName}; trusted_connection=true;";
+                   ?? $"server=.; database={databaseName}; trusted_connection=true;";
         }
     }
 }

--- a/Rebus.SqlServer.Tests/SqlTestHelper.cs
+++ b/Rebus.SqlServer.Tests/SqlTestHelper.cs
@@ -210,7 +210,7 @@ namespace Rebus.SqlServer.Tests
         static string GetConnectionStringForDatabase(string databaseName)
         {
             return Environment.GetEnvironmentVariable("REBUS_SQLSERVER")
-                   ?? $"server=.; database={databaseName}; trusted_connection=true;";
+                   ?? $"server=.\\SqlExpress; database={databaseName}; trusted_connection=true;";
         }
     }
 }

--- a/Rebus.SqlServer.Tests/Transport/Contract/Factories/SqlLeaseTransportFactory.cs
+++ b/Rebus.SqlServer.Tests/Transport/Contract/Factories/SqlLeaseTransportFactory.cs
@@ -27,7 +27,7 @@ namespace Rebus.SqlServer.Tests.Transport.Contract.Factories
             var connectionProvider = new DbConnectionProvider(SqlTestHelper.ConnectionString, consoleLoggerFactory);
             var asyncTaskFactory = new TplAsyncTaskFactory(consoleLoggerFactory);
             var transport = new SqlServerLeaseTransport(connectionProvider, tableName, null, consoleLoggerFactory,
-                asyncTaskFactory, TimeSpan.FromMinutes(1), TimeSpan.FromSeconds(2));
+                asyncTaskFactory, TimeSpan.FromMinutes(1), TimeSpan.FromSeconds(2), () => Environment.MachineName);
             //var transport = new SqlServerTransport(connectionProvider, tableName, null, consoleLoggerFactory, asyncTaskFactory);
 
             _disposables.Add(transport);
@@ -50,7 +50,7 @@ namespace Rebus.SqlServer.Tests.Transport.Contract.Factories
             var connectionProvider = new DbConnectionProvider(SqlTestHelper.ConnectionString, consoleLoggerFactory);
             var asyncTaskFactory = new TplAsyncTaskFactory(consoleLoggerFactory);
             var transport = new SqlServerLeaseTransport(connectionProvider, tableName, inputQueueAddress, consoleLoggerFactory,
-                asyncTaskFactory, TimeSpan.FromMinutes(1), TimeSpan.FromSeconds(2));
+                asyncTaskFactory, TimeSpan.FromMinutes(1), TimeSpan.FromSeconds(2), () => Environment.MachineName);
 //            var transport = new SqlServerTransport(connectionProvider, tableName, inputQueueAddress, consoleLoggerFactory, asyncTaskFactory);
             
             _disposables.Add(transport);

--- a/Rebus.SqlServer/SqlServer/Transport/SqlServerLeaseTransport.cs
+++ b/Rebus.SqlServer/SqlServer/Transport/SqlServerLeaseTransport.cs
@@ -165,7 +165,7 @@ OUTPUT	inserted.*";
 	    /// <summary>
 	    /// Provides an oppurtunity for derived implementations to also update the schema
 	    /// </summary>
-	    protected override string AdditionalSchenaModifications(IDbConnection connection) {
+	    protected override string AdditionalSchemaModifications(IDbConnection connection) {
 			return $@"
 IF NOT EXISTS (SELECT 1 FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA = '{TableName.Schema}' AND TABLE_NAME = '{TableName.Name}' AND COLUMN_NAME = 'leaseduntil')
 BEGIN

--- a/Rebus.SqlServer/SqlServer/Transport/SqlServerLeaseTransport.cs
+++ b/Rebus.SqlServer/SqlServer/Transport/SqlServerLeaseTransport.cs
@@ -17,10 +17,15 @@ namespace Rebus.SqlServer.Transport
 	/// </summary>
     public class SqlServerLeaseTransport : SqlServerTransport
     {
-		/// <summary>
+	    /// <summary>
 		/// Key for storing the outbound message buffer when performing <seealso cref="Send"/>
 		/// </summary>
 	    public const string OutboundMessageBufferKey = "sql-server-transport-leased-outbound-message-buffer";
+
+		/// <summary>
+		/// Size of the leasedby column
+		/// </summary>
+	    public const int LeasedByColumnSize = 200;
 
 		/// <summary>
 		/// If not specified the default time messages are leased for
@@ -37,15 +42,25 @@ namespace Rebus.SqlServer.Transport
 		/// </summary>
 		public static readonly TimeSpan DefaultLeaseAutomaticRenewal = TimeSpan.FromSeconds(150);
 
-	    readonly long _leaseIntervalMilliseconds;
-	    readonly long _leaseToleranceMilliseconds;
-	    readonly bool _automaticLeaseRenewal;
-	    readonly long _automaticLeaseRenewalIntervalMilliseconds;
+		readonly long _leaseIntervalMilliseconds;
+		readonly long _leaseToleranceMilliseconds;
+		readonly bool _automaticLeaseRenewal;
+		readonly long _automaticLeaseRenewalIntervalMilliseconds;
+		readonly Func<string> _leasedByFactory;
 
 		/// <summary>
 		/// Constructor
 		/// </summary>
-	    public SqlServerLeaseTransport(
+		/// <param name="connectionProvider">A <see cref="IDbConnection"/> to obtain a database connection</param>
+		/// <param name="tableName">Name of the table to store messages in</param>
+		/// <param name="inputQueueName">Name of the queue this transport is servicing</param>
+		/// <param name="rebusLoggerFactory">A <seealso cref="IRebusLoggerFactory"/> for building loggers</param>
+		/// <param name="asyncTaskFactory">A <seealso cref="IAsyncTaskFactory"/> for creating periodic tasks</param>
+		/// <param name="leaseInterval">Interval of time messages are leased for</param>
+		/// <param name="leaseTolerance">Buffer to allow lease overruns by</param>
+		/// <param name="leasedByFactory">Factory for generating a string which identifies who has leased a message (eg. A hostname)</param>
+		/// <param name="automaticLeaseRenewalInterval">If non-<c>null</c> messages will be automatically re-leased after this time period has elapsed</param>
+		public SqlServerLeaseTransport(
 			IDbConnectionProvider connectionProvider, 
 			string tableName, 
 			string inputQueueName, 
@@ -53,9 +68,11 @@ namespace Rebus.SqlServer.Transport
 			IAsyncTaskFactory asyncTaskFactory,
 			TimeSpan leaseInterval, 
 			TimeSpan? leaseTolerance,
+			Func<string> leasedByFactory,
 			TimeSpan? automaticLeaseRenewalInterval = null
 			) : base(connectionProvider, tableName, inputQueueName, rebusLoggerFactory, asyncTaskFactory)
 		{
+			_leasedByFactory = leasedByFactory;
 			_leaseIntervalMilliseconds = (long)Math.Ceiling(leaseInterval.TotalMilliseconds);
 			_leaseToleranceMilliseconds = (long)Math.Ceiling((leaseTolerance ?? TimeSpan.FromSeconds(15)).TotalMilliseconds);
 			if (automaticLeaseRenewalInterval.HasValue == false) {
@@ -99,7 +116,8 @@ namespace Rebus.SqlServer.Transport
 			[id],
 			[headers],
 			[body],
-			[leaseduntil]
+			[leaseduntil],
+			[leasedby]
 	FROM	{TableName.QualifiedName} M WITH (ROWLOCK, READPAST)
 	WHERE	M.[recipient] = @recipient
 	AND		M.[visible] < getdate()
@@ -114,11 +132,13 @@ namespace Rebus.SqlServer.Transport
 			[id] ASC
 )
 UPDATE	TopCTE WITH (ROWLOCK)
-SET		leaseduntil = DATEADD(ms, @leasemilliseconds, getdate())
+SET		leaseduntil = DATEADD(ms, @leasemilliseconds, getdate()),
+		leasedby = @leasedby
 OUTPUT	inserted.*";
 					selectCommand.Parameters.Add("@recipient", SqlDbType.NVarChar, RecipientColumnSize).Value = InputQueueName;
 					selectCommand.Parameters.Add("@leasemilliseconds", SqlDbType.BigInt).Value = _leaseIntervalMilliseconds;
 					selectCommand.Parameters.Add("@leasetolerancemilliseconds", SqlDbType.BigInt).Value = _leaseToleranceMilliseconds;
+					selectCommand.Parameters.Add("@leasedby", SqlDbType.VarChar, LeasedByColumnSize).Value = _leasedByFactory();
 
 					try {
 						using (SqlDataReader reader = await selectCommand.ExecuteReaderAsync(cancellationToken)) {
@@ -150,6 +170,13 @@ OUTPUT	inserted.*";
 IF NOT EXISTS (SELECT 1 FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA = '{TableName.Schema}' AND TABLE_NAME = '{TableName.Name}' AND COLUMN_NAME = 'leaseduntil')
 BEGIN
 	ALTER TABLE {TableName.QualifiedName} ADD leaseduntil datetime2 null
+END
+
+----
+
+IF NOT EXISTS (SELECT 1 FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA = '{TableName.Schema}' AND TABLE_NAME = '{TableName.Name}' AND COLUMN_NAME = 'leasedby')
+BEGIN
+	ALTER TABLE {TableName.QualifiedName} ADD leasedby nvarchar({LeasedByColumnSize}) null
 END
 ";
 		}
@@ -235,7 +262,6 @@ WHERE	id = @id
 		/// <param name="tableName">Name of the table the messages are stored in</param>
 		/// <param name="messageId">Identifier of the message whose lease is being updated</param>
 		/// <param name="leaseIntervalMilliseconds">New lease interval in milliseconds. If <c>null</c> the lease will be released</param>
-		/// <returns></returns>
 		private static async Task UpdateLease(IDbConnectionProvider connectionProvider, string tableName, long messageId, long? leaseIntervalMilliseconds)
 		{
 			using (IDbConnection connection = await connectionProvider.GetConnection()) {
@@ -244,8 +270,12 @@ WHERE	id = @id
 					command.CommandText = $@"
 UPDATE	{tableName} WITH (ROWLOCK)
 SET		leaseduntil =	CASE
-							WHEN @leaseintervalmilliseconds IS NULL then NULL
+							WHEN @leaseintervalmilliseconds IS NULL THEN NULL
 							ELSE dateadd(ms, @leaseintervalmilliseconds, getdate())
+						END,
+		leasedby	=	CASE
+							WHEN @leaseintervalmilliseconds IS NULL THEN NULL
+							ELSE leasedby
 						END
 WHERE	id = @id
 ";

--- a/Rebus.SqlServer/SqlServer/Transport/SqlServerTransport.cs
+++ b/Rebus.SqlServer/SqlServer/Transport/SqlServerTransport.cs
@@ -140,7 +140,7 @@ namespace Rebus.SqlServer.Transport
 		/// <summary>
 		/// Provides an oppurtunity for derived implementations to also update the schema
 		/// </summary>
-		protected virtual string AdditionalSchenaModifications(IDbConnection connection)
+		protected virtual string AdditionalSchemaModifications(IDbConnection connection)
 		{
 			return string.Empty;
 		}
@@ -155,7 +155,7 @@ namespace Rebus.SqlServer.Transport
 				if (tableNames.Contains(TableName))
                 {
                     _log.Info("Database already contains a table named {tableName} - will not create anything", TableName.QualifiedName);
-					additional = AdditionalSchenaModifications(connection);
+					additional = AdditionalSchemaModifications(connection);
 					ExecuteCommands(connection, additional);
 
 					connection.Complete().Wait();
@@ -213,7 +213,7 @@ IF NOT EXISTS (SELECT 1 FROM sys.indexes WHERE name = '{expirationIndexName}')
 
 ");
 
-	            additional = AdditionalSchenaModifications(connection);
+	            additional = AdditionalSchemaModifications(connection);
 	            ExecuteCommands(connection, additional);
 
 				connection.Complete().Wait();


### PR DESCRIPTION
For now just a column useful for introspection scenarios. In future it may be used to further validate the lease (eg. Option to not allow renewal / forceful takeover of a lease if it belongs to someone else. Needs thought for cloud scenarios where entire workers may vanish)

---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.
