### PR TITLE
NET45: Added ambient transaction support.

### DIFF
--- a/Rebus.SqlServer.Tests/Rebus.SqlServer.Tests.csproj
+++ b/Rebus.SqlServer.Tests/Rebus.SqlServer.Tests.csproj
@@ -46,4 +46,7 @@
     <PackageReference Include="rebus" Version="4.0.1" />
     <PackageReference Include="rebus.tests.contracts" Version="4.0.1" />
   </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
+    <Reference Include="System.Transactions" />
+  </ItemGroup>
 </Project>

--- a/Rebus.SqlServer.Tests/Transport/TestDbConnectionProvider.cs
+++ b/Rebus.SqlServer.Tests/Transport/TestDbConnectionProvider.cs
@@ -1,9 +1,14 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Threading.Tasks;
+#if NET45
+using System.Transactions;
+#endif
 using NUnit.Framework;
 using Rebus.Logging;
 
 namespace Rebus.SqlServer.Tests.Transport
 {
+
     [TestFixture, Category(Categories.SqlServer)]
     public class TestDbConnectionProvider
     {
@@ -24,5 +29,31 @@ namespace Rebus.SqlServer.Tests.Transport
                 //await dbConnection.Complete();
             }
         }
+#if NET45
+        [Test, Ignore("assumes existence of a bimse table")]
+        public async Task CanDoWorkInAmbientTransaction()
+        {
+            using (var tx = new TransactionScope(TransactionScopeOption.Required, new TransactionOptions
+            {
+                IsolationLevel = IsolationLevel.ReadCommitted,
+                Timeout = TimeSpan.FromSeconds(60)
+            }))
+            {
+                var provizzle = new DbConnectionProvider(SqlTestHelper.ConnectionString, new ConsoleLoggerFactory(true), 
+                    enlistInAmbientTransaction: true);
+
+                using (var dbConnection = await provizzle.GetConnection())
+                {
+                    using (var cmd = dbConnection.CreateCommand())
+                    {
+                        cmd.CommandText = "insert into bimse (text) values ('Nogen fjellaper liger 2PC')";
+                    
+                        await cmd.ExecuteNonQueryAsync();
+                    }
+                }
+                // tx.Complete();
+            }
+        }
+#endif
     }
 }

--- a/Rebus.SqlServer/Config/SqlServerDataBusConfigurationExtensions.cs
+++ b/Rebus.SqlServer/Config/SqlServerDataBusConfigurationExtensions.cs
@@ -15,7 +15,11 @@ namespace Rebus.Config
         /// <summary>
         /// Configures the data bus to store data in a central SQL Server 
         /// </summary>
-        public static void StoreInSqlServer(this StandardConfigurer<IDataBusStorage> configurer, string connectionStringOrConnectionStringName, string tableName, bool automaticallyCreateTables = true, int commandTimeout = 240)
+        public static void StoreInSqlServer(this StandardConfigurer<IDataBusStorage> configurer, string connectionStringOrConnectionStringName, string tableName, bool automaticallyCreateTables = true, int commandTimeout = 240
+#if NET45
+        , bool enlistInAmbientTransaction = false
+#endif
+        )
         {
             if (configurer == null) throw new ArgumentNullException(nameof(configurer));
             if (connectionStringOrConnectionStringName == null) throw new ArgumentNullException(nameof(connectionStringOrConnectionStringName));
@@ -24,7 +28,11 @@ namespace Rebus.Config
             configurer.Register(c =>
             {
                 var loggerFactory = c.Get<IRebusLoggerFactory>();
-                var connectionProvider = new DbConnectionProvider(connectionStringOrConnectionStringName, loggerFactory);
+                var connectionProvider = new DbConnectionProvider(connectionStringOrConnectionStringName, loggerFactory
+#if NET45
+                    , enlistInAmbientTransaction
+#endif
+                );
                 return new SqlServerDataBusStorage(connectionProvider, tableName, automaticallyCreateTables, loggerFactory, commandTimeout);
             });
         }

--- a/Rebus.SqlServer/Config/SqlServerSagaConfigurationExtensions.cs
+++ b/Rebus.SqlServer/Config/SqlServerSagaConfigurationExtensions.cs
@@ -17,7 +17,11 @@ namespace Rebus.Config
         /// </summary>
         public static void StoreInSqlServer(this StandardConfigurer<ISagaStorage> configurer,
             string connectionStringOrConnectionStringName, string dataTableName, string indexTableName,
-            bool automaticallyCreateTables = true)
+            bool automaticallyCreateTables = true
+#if NET45
+            ,bool enlistInAmbientTransaction = false
+#endif
+    )
         {
             if (configurer == null) throw new ArgumentNullException(nameof(configurer));
             if (connectionStringOrConnectionStringName == null) throw new ArgumentNullException(nameof(connectionStringOrConnectionStringName));
@@ -27,7 +31,11 @@ namespace Rebus.Config
             configurer.Register(c =>
             {
                 var rebusLoggerFactory = c.Get<IRebusLoggerFactory>();
-                var connectionProvider = new DbConnectionProvider(connectionStringOrConnectionStringName, rebusLoggerFactory);
+                var connectionProvider = new DbConnectionProvider(connectionStringOrConnectionStringName, rebusLoggerFactory
+#if NET45
+                    , enlistInAmbientTransaction
+#endif
+    );
                 var sagaStorage = new SqlServerSagaStorage(connectionProvider, dataTableName, indexTableName, rebusLoggerFactory);
 
                 if (automaticallyCreateTables)

--- a/Rebus.SqlServer/Config/SqlServerSagaSnapshotsConfigurationExtensions.cs
+++ b/Rebus.SqlServer/Config/SqlServerSagaSnapshotsConfigurationExtensions.cs
@@ -16,7 +16,11 @@ namespace Rebus.Config
         /// Configures Rebus to store saga snapshots in SQL Server
         /// </summary>
         public static void StoreInSqlServer(this StandardConfigurer<ISagaSnapshotStorage> configurer,
-            string connectionStringOrConnectionStringName, string tableName, bool automaticallyCreateTables = true)
+            string connectionStringOrConnectionStringName, string tableName, bool automaticallyCreateTables = true
+#if NET45
+            , bool enlistInAmbientTransaction = false
+#endif
+            )
         {
             if (configurer == null) throw new ArgumentNullException(nameof(configurer));
             if (connectionStringOrConnectionStringName == null) throw new ArgumentNullException(nameof(connectionStringOrConnectionStringName));
@@ -25,7 +29,11 @@ namespace Rebus.Config
             configurer.Register(c =>
             {
                 var rebusLoggerFactory = c.Get<IRebusLoggerFactory>();
-                var connectionProvider = new DbConnectionProvider(connectionStringOrConnectionStringName, rebusLoggerFactory);
+                var connectionProvider = new DbConnectionProvider(connectionStringOrConnectionStringName, rebusLoggerFactory
+#if NET45
+                    , enlistInAmbientTransaction
+#endif
+                    );
                 var snapshotStorage = new SqlServerSagaSnapshotStorage(connectionProvider, tableName, rebusLoggerFactory);
 
                 if (automaticallyCreateTables)

--- a/Rebus.SqlServer/Config/SqlServerSubscriptionsConfigurationExtensions.cs
+++ b/Rebus.SqlServer/Config/SqlServerSubscriptionsConfigurationExtensions.cs
@@ -18,7 +18,11 @@ namespace Rebus.Config
         /// default behavior.
         /// </summary>
         public static void StoreInSqlServer(this StandardConfigurer<ISubscriptionStorage> configurer,
-            string connectionStringOrConnectionStringName, string tableName, bool isCentralized = false, bool automaticallyCreateTables = true)
+            string connectionStringOrConnectionStringName, string tableName, bool isCentralized = false, bool automaticallyCreateTables = true
+#if NET45
+            , bool enlistInAmbientTransaction = false
+#endif 
+            )
         {
             if (configurer == null) throw new ArgumentNullException(nameof(configurer));
             if (connectionStringOrConnectionStringName == null) throw new ArgumentNullException(nameof(connectionStringOrConnectionStringName));
@@ -27,7 +31,11 @@ namespace Rebus.Config
             configurer.Register(c =>
             {
                 var rebusLoggerFactory = c.Get<IRebusLoggerFactory>();
-                var connectionProvider = new DbConnectionProvider(connectionStringOrConnectionStringName, rebusLoggerFactory);
+                var connectionProvider = new DbConnectionProvider(connectionStringOrConnectionStringName, rebusLoggerFactory
+#if NET45
+                    , enlistInAmbientTransaction
+#endif                
+                );
                 var subscriptionStorage = new SqlServerSubscriptionStorage(connectionProvider, tableName, isCentralized, rebusLoggerFactory);
 
                 if (automaticallyCreateTables)

--- a/Rebus.SqlServer/Config/SqlServerTimeoutsConfigurationExtensions.cs
+++ b/Rebus.SqlServer/Config/SqlServerTimeoutsConfigurationExtensions.cs
@@ -16,7 +16,11 @@ namespace Rebus.Config
         /// Configures Rebus to use SQL Server to store timeouts.
         /// </summary>
         public static void StoreInSqlServer(this StandardConfigurer<ITimeoutManager> configurer, 
-            string connectionStringOrConnectionStringName, string tableName, bool automaticallyCreateTables = true)
+            string connectionStringOrConnectionStringName, string tableName, bool automaticallyCreateTables = true
+#if NET45
+            , bool enlistInAmbientTransaction = false
+#endif 
+            )
         {
             if (configurer == null) throw new ArgumentNullException(nameof(configurer));
             if (connectionStringOrConnectionStringName == null) throw new ArgumentNullException(nameof(connectionStringOrConnectionStringName));
@@ -25,7 +29,11 @@ namespace Rebus.Config
             configurer.Register(c =>
             {
                 var rebusLoggerFactory = c.Get<IRebusLoggerFactory>();
-                var connectionProvider = new DbConnectionProvider(connectionStringOrConnectionStringName, rebusLoggerFactory);
+                var connectionProvider = new DbConnectionProvider(connectionStringOrConnectionStringName, rebusLoggerFactory
+#if NET45
+                    , enlistInAmbientTransaction
+#endif
+                );
                 var subscriptionStorage = new SqlServerTimeoutManager(connectionProvider, tableName, rebusLoggerFactory);
 
                 if (automaticallyCreateTables)

--- a/Rebus.SqlServer/Config/SqlServerTransportConfigurationExtensions.cs
+++ b/Rebus.SqlServer/Config/SqlServerTransportConfigurationExtensions.cs
@@ -30,9 +30,18 @@ namespace Rebus.Config
         /// <param name="automaticallyRenewLeases">If <c>true</c> then workers will automatically renew the lease they have acquired whilst they're still processing the message. This will occur in accordance with <paramref name="leaseAutoRenewInterval"/></param>
         /// <param name="leaseAutoRenewInterval">If <c>null</c> defaults to <seealso cref="SqlServerLeaseTransport.DefaultLeaseAutomaticRenewal"/>. Specifies how frequently a lease will be renewed whilst the worker is processing a message. Lower values decrease the chance of other workers processing the same message but increase DB communication. A value 50% of <paramref name="leaseInterval"/> should be appropriate</param>
         /// <param name="leasedByFactory">If non-<c>null</c> a factory which returns a string identifying this worker when it leases a message. If <c>null></c> the current machine name is used</param>
-        public static void UseSqlServerInLeaseModeAsOneWayClient(this StandardConfigurer<ITransport> configurer, string connectionStringOrConnectionStringName, TimeSpan? leaseInterval = null, TimeSpan? leaseTolerance = null, bool automaticallyRenewLeases = false, TimeSpan? leaseAutoRenewInterval = null, Func<string> leasedByFactory = null)
+        /// <param name="enlistInAmbientTransaction">If <c>true</c> the connection will be enlisted in the ambient transaction if it exists, else it will create an SqlTransaction and enlist in it</param>
+        public static void UseSqlServerInLeaseModeAsOneWayClient(this StandardConfigurer<ITransport> configurer, string connectionStringOrConnectionStringName, TimeSpan? leaseInterval = null, TimeSpan? leaseTolerance = null, bool automaticallyRenewLeases = false, TimeSpan? leaseAutoRenewInterval = null, Func<string> leasedByFactory = null
+#if NET45
+        , bool enlistInAmbientTransaction = false
+#endif
+        )
         {
-            ConfigureInLeaseMode(configurer, loggerFactory => new DbConnectionProvider(connectionStringOrConnectionStringName, loggerFactory), null, leaseInterval, leaseTolerance, automaticallyRenewLeases, leaseAutoRenewInterval);
+            ConfigureInLeaseMode(configurer, loggerFactory => new DbConnectionProvider(connectionStringOrConnectionStringName, loggerFactory
+#if NET45
+            ,enlistInAmbientTransaction
+#endif
+            ), null, leaseInterval, leaseTolerance, automaticallyRenewLeases, leaseAutoRenewInterval);
 
             OneWayClientBackdoor.ConfigureOneWayClient(configurer);
         }
@@ -68,9 +77,18 @@ namespace Rebus.Config
         /// <param name="automaticallyRenewLeases">If <c>true</c> then workers will automatically renew the lease they have acquired whilst they're still processing the message. This will occur in accordance with <paramref name="leaseAutoRenewInterval"/></param>
         /// <param name="leaseAutoRenewInterval">If <c>null</c> defaults to <seealso cref="SqlServerLeaseTransport.DefaultLeaseAutomaticRenewal"/>. Specifies how frequently a lease will be renewed whilst the worker is processing a message. Lower values decrease the chance of other workers processing the same message but increase DB communication. A value 50% of <paramref name="leaseInterval"/> should be appropriate</param>
         /// <param name="leasedByFactory">If non-<c>null</c> a factory which returns a string identifying this worker when it leases a message. If <c>null></c> the current machine name is used</param>
-        public static void UseSqlServerInLeaseMode(this StandardConfigurer<ITransport> configurer, string connectionStringOrConnectionStringName, string inputQueueName, TimeSpan? leaseInterval = null, TimeSpan? leaseTolerance = null, bool automaticallyRenewLeases = false, TimeSpan? leaseAutoRenewInterval = null, Func<string> leasedByFactory = null)
+        /// <param name="enlistInAmbientTransaction">If <c>true</c> the connection will be enlisted in the ambient transaction if it exists, else it will create an SqlTransaction and enlist in it</param>
+        public static void UseSqlServerInLeaseMode(this StandardConfigurer<ITransport> configurer, string connectionStringOrConnectionStringName, string inputQueueName, TimeSpan? leaseInterval = null, TimeSpan? leaseTolerance = null, bool automaticallyRenewLeases = false, TimeSpan? leaseAutoRenewInterval = null, Func<string> leasedByFactory = null
+#if NET45
+        , bool enlistInAmbientTransaction = false
+#endif
+        )
         {
-            ConfigureInLeaseMode(configurer, loggerFactory => new DbConnectionProvider(connectionStringOrConnectionStringName, loggerFactory), inputQueueName, leaseInterval, leaseTolerance, automaticallyRenewLeases, leaseAutoRenewInterval);
+            ConfigureInLeaseMode(configurer, loggerFactory => new DbConnectionProvider(connectionStringOrConnectionStringName, loggerFactory
+#if NET45
+            , enlistInAmbientTransaction
+#endif
+            ), inputQueueName, leaseInterval, leaseTolerance, automaticallyRenewLeases, leaseAutoRenewInterval);
         }
 
         /// <summary>
@@ -133,9 +151,17 @@ namespace Rebus.Config
         /// Configures Rebus to use SQL Server to transport messages as a one-way client (i.e. will not be able to receive any messages).
         /// The message table will automatically be created if it does not exist.
         /// </summary>
-        public static void UseSqlServerAsOneWayClient(this StandardConfigurer<ITransport> configurer, string connectionStringOrConnectionStringName)
+        public static void UseSqlServerAsOneWayClient(this StandardConfigurer<ITransport> configurer, string connectionStringOrConnectionStringName
+#if NET45
+            , bool enlistInAmbientTransaction = false
+#endif
+        )
         {
-            Configure(configurer, loggerFactory => new DbConnectionProvider(connectionStringOrConnectionStringName, loggerFactory), null, (context, provider, inputQueue) => new SqlServerTransport(provider, inputQueue, context.Get<IRebusLoggerFactory>(), context.Get<IAsyncTaskFactory>()));
+            Configure(configurer, loggerFactory => new DbConnectionProvider(connectionStringOrConnectionStringName, loggerFactory
+#if NET45
+            , enlistInAmbientTransaction
+#endif
+            ), null, (context, provider, inputQueue) => new SqlServerTransport(provider, inputQueue, context.Get<IRebusLoggerFactory>(), context.Get<IAsyncTaskFactory>()));
 
             OneWayClientBackdoor.ConfigureOneWayClient(configurer);
         }
@@ -153,9 +179,17 @@ namespace Rebus.Config
         /// Configures Rebus to use SQL Server as its transport. The "queue" specified by <paramref name="inputQueueName"/> will be used when querying for messages.
         /// The message table will automatically be created if it does not exist.
         /// </summary>
-        public static void UseSqlServer(this StandardConfigurer<ITransport> configurer, string connectionStringOrConnectionStringName, string inputQueueName)
+        public static void UseSqlServer(this StandardConfigurer<ITransport> configurer, string connectionStringOrConnectionStringName, string inputQueueName
+#if NET45
+            , bool enlistInAmbientTransaction = false
+#endif 
+        )
         {
-            Configure(configurer, loggerFactory => new DbConnectionProvider(connectionStringOrConnectionStringName, loggerFactory), inputQueueName);
+            Configure(configurer, loggerFactory => new DbConnectionProvider(connectionStringOrConnectionStringName, loggerFactory
+#if NET45
+                , enlistInAmbientTransaction
+#endif
+            ), inputQueueName);
         }
 
 

--- a/Rebus.SqlServer/Config/SqlServerTransportConfigurationExtensions.cs
+++ b/Rebus.SqlServer/Config/SqlServerTransportConfigurationExtensions.cs
@@ -10,6 +10,9 @@ using Rebus.Threading;
 using Rebus.Timeouts;
 using Rebus.Transport;
 
+// multi-platform stuff is hard for XML doc comments...
+#pragma warning disable 1572
+
 namespace Rebus.Config
 {
     /// <summary>
@@ -241,3 +244,4 @@ namespace Rebus.Config
         }
     }
 }
+#pragma warning restore 1591

--- a/Rebus.SqlServer/Rebus.SqlServer.csproj
+++ b/Rebus.SqlServer/Rebus.SqlServer.csproj
@@ -10,7 +10,7 @@
     <Authors>mookid8000</Authors>
     <PackageLicenseUrl>https://raw.githubusercontent.com/rebus-org/Rebus/master/LICENSE.md</PackageLicenseUrl>
     <PackageProjectUrl>http://mookid.dk/oncode/rebus</PackageProjectUrl>
-    <Copyright>Copyright 2012-2016</Copyright>
+    <Copyright>Copyright 2012-2018</Copyright>
     <PackageTags>rebus queue messaging service bus sql-server sqlserver mssql sql</PackageTags>
     <PackageIconUrl>https://github.com/mookid8000/Rebus/raw/master/artwork/little_rebusbus2_copy-200x200.png</PackageIconUrl>
     <RepositoryUrl>https://github.com/rebus-org/Rebus</RepositoryUrl>
@@ -53,7 +53,7 @@
     <Reference Include="System.Data.Common" />
     <PackageReference Include="System.Data.SqlClient" Version="4.1.0" />
   </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net45'">
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Core" />
     <Reference Include="System.Configuration" />


### PR DESCRIPTION
Adds support for enlistment in ambient transactions (if present).

AFAIK all changes are backwards compatible; adds a ```bool enlistInAmbientTransaction``` to the methods in question with a default value set to ```false```.

---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.
