### PR TITLE
Clear the timer incase Dispose() is called multiple times

### DIFF
--- a/Rebus.SqlServer/SqlServer/Transport/SqlServerLeaseTransport.cs
+++ b/Rebus.SqlServer/SqlServer/Transport/SqlServerLeaseTransport.cs
@@ -333,7 +333,7 @@ WHERE	id = @id
             readonly long _messageId;
             readonly IDbConnectionProvider _connectionProvider;
             readonly long _leaseIntervalMilliseconds;
-            readonly Timer _renewTimer;
+            Timer _renewTimer;
 
             public AutomaticLeaseRenewer(string tableName, long messageId, IDbConnectionProvider connectionProvider, long renewIntervalMilliseconds, long leaseIntervalMilliseconds)
             {
@@ -349,6 +349,7 @@ WHERE	id = @id
             {
                 _renewTimer?.Change(TimeSpan.FromMilliseconds(-1), TimeSpan.FromMilliseconds(-1));
                 _renewTimer?.Dispose();
+	            _renewTimer = null;
             }
 
             async void RenewLease(object state)


### PR DESCRIPTION
We've seen an issue a few times where the timer for the `AutomaticLeaseRenewer` was throwing because the timer had already been `Dispose()`ed when attempting to clear the timer (as part of `Dispose()`). For safety set the timer to `NULL` in `Dispose()`.

---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.
