### PR TITLE
Fix issue 39 (the sql connection is closed by default, so open it first)

### DIFF
--- a/Rebus.SqlServer/SqlServer/DbConnectionProvider.cs
+++ b/Rebus.SqlServer/SqlServer/DbConnectionProvider.cs
@@ -84,7 +84,10 @@ namespace Rebus.SqlServer
         SqlConnection CreateSqlConnectionInAPossiblyAmbientTransaction()
         {
             var connection = new SqlConnection(_connectionString);
-            
+
+            // do not use Async here! it would cause the tx scope to be disposed on another thread than the one that created it
+            connection.Open();
+
             var transaction = System.Transactions.Transaction.Current;
             if (transaction != null)
             {


### PR DESCRIPTION
Fixes [issue 39](https://github.com/rebus-org/Rebus.SqlServer/issues/39).

---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.
