### PR TITLE
Update to rebus version 6

### DIFF
--- a/Rebus.SqlServer.Tests/Bugs/TestBugWhenSendingMessagesInParallel.cs
+++ b/Rebus.SqlServer.Tests/Bugs/TestBugWhenSendingMessagesInParallel.cs
@@ -7,7 +7,6 @@ using Rebus.Activation;
 using Rebus.Bus;
 using Rebus.Config;
 using Rebus.Logging;
-using Rebus.SqlServer.Transport;
 using Rebus.Tests.Contracts;
 using Rebus.Tests.Contracts.Extensions;
 

--- a/Rebus.SqlServer.Tests/Bugs/TestConcurrencyAndSnapshotIsolation.cs
+++ b/Rebus.SqlServer.Tests/Bugs/TestConcurrencyAndSnapshotIsolation.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Data;
 using System.Text;
 using System.Threading;
@@ -10,6 +9,7 @@ using Rebus.Messages;
 using Rebus.SqlServer.Transport;
 using Rebus.Tests.Contracts;
 using Rebus.Threading.TaskParallelLibrary;
+using Rebus.Time;
 using Rebus.Transport;
 
 namespace Rebus.SqlServer.Tests.Bugs
@@ -70,19 +70,22 @@ namespace Rebus.SqlServer.Tests.Bugs
 
         SqlServerTransport GetTransport(string connectionString, IsolationLevel isolationLevel)
         {
+            var rebusTime = new DefaultRebusTime();
             var rebusLoggerFactory = new ConsoleLoggerFactory(false);
 
             var connectionProvider = new DbConnectionProvider(connectionString, rebusLoggerFactory)
             {
                 IsolationLevel = isolationLevel
             };
+
             var taskFactory = new TplAsyncTaskFactory(rebusLoggerFactory);
 
             var transport = new SqlServerTransport(
                 connectionProvider: connectionProvider,
                 inputQueueName: _queueName,
                 rebusLoggerFactory: rebusLoggerFactory,
-                asyncTaskFactory: taskFactory
+                asyncTaskFactory: taskFactory,
+                rebusTime: rebusTime
             );
 
             transport.Initialize();

--- a/Rebus.SqlServer.Tests/Bugs/TestNativeDeferToSomeoneElse.cs
+++ b/Rebus.SqlServer.Tests/Bugs/TestNativeDeferToSomeoneElse.cs
@@ -10,7 +10,6 @@ using Rebus.Messages;
 using Rebus.Pipeline;
 using Rebus.Routing;
 using Rebus.Routing.TypeBased;
-using Rebus.SqlServer.Transport;
 using Rebus.Tests.Contracts;
 using Rebus.Tests.Contracts.Extensions;
 

--- a/Rebus.SqlServer.Tests/DataBus/SqlServerDataBusStorageFactory.cs
+++ b/Rebus.SqlServer.Tests/DataBus/SqlServerDataBusStorageFactory.cs
@@ -2,6 +2,7 @@
 using Rebus.Logging;
 using Rebus.SqlServer.DataBus;
 using Rebus.Tests.Contracts.DataBus;
+using Rebus.Time;
 
 namespace Rebus.SqlServer.Tests.DataBus
 {
@@ -14,9 +15,10 @@ namespace Rebus.SqlServer.Tests.DataBus
 
         public IDataBusStorage Create()
         {
+            var rebusTime = new DefaultRebusTime();
             var consoleLoggerFactory = new ConsoleLoggerFactory(false);
             var connectionProvider = new DbConnectionProvider(SqlTestHelper.ConnectionString, consoleLoggerFactory);
-            var sqlServerDataBusStorage = new SqlServerDataBusStorage(connectionProvider, "databus", true, consoleLoggerFactory, 240);
+            var sqlServerDataBusStorage = new SqlServerDataBusStorage(connectionProvider, "databus", true, consoleLoggerFactory, rebusTime, 240);
             sqlServerDataBusStorage.Initialize();
             return sqlServerDataBusStorage;
         }

--- a/Rebus.SqlServer.Tests/DataBus/TestSqlServerDataBusStorage.cs
+++ b/Rebus.SqlServer.Tests/DataBus/TestSqlServerDataBusStorage.cs
@@ -10,6 +10,7 @@ using Rebus.Logging;
 using Rebus.SqlServer.DataBus;
 using Rebus.Tests.Contracts;
 using Rebus.Tests.Contracts.Extensions;
+using Rebus.Time;
 
 namespace Rebus.SqlServer.Tests.DataBus
 {
@@ -20,6 +21,7 @@ namespace Rebus.SqlServer.Tests.DataBus
 
         protected override void SetUp()
         {
+            var rebusTime = new DefaultRebusTime();
             var loggerFactory = new ConsoleLoggerFactory(false);
             var connectionProvider = new DbConnectionProvider(SqlTestHelper.ConnectionString, loggerFactory);
 
@@ -27,7 +29,7 @@ namespace Rebus.SqlServer.Tests.DataBus
 
             SqlTestHelper.DropTable(tableName);
 
-            _storage = new SqlServerDataBusStorage(connectionProvider, tableName, true, loggerFactory, 240);
+            _storage = new SqlServerDataBusStorage(connectionProvider, tableName, true, loggerFactory, rebusTime, 240);
             _storage.Initialize();
         }
 

--- a/Rebus.SqlServer.Tests/Integration/NativeDeferTest.cs
+++ b/Rebus.SqlServer.Tests/Integration/NativeDeferTest.cs
@@ -7,7 +7,6 @@ using Rebus.Bus;
 using Rebus.Config;
 using Rebus.Messages;
 using Rebus.Routing.TypeBased;
-using Rebus.SqlServer.Transport;
 using Rebus.Tests.Contracts;
 using Rebus.Tests.Contracts.Extensions;
 

--- a/Rebus.SqlServer.Tests/Integration/TestNumberOfSqlConnections.cs
+++ b/Rebus.SqlServer.Tests/Integration/TestNumberOfSqlConnections.cs
@@ -11,6 +11,7 @@ using Rebus.Logging;
 using Rebus.SqlServer.Transport;
 using Rebus.Tests.Contracts;
 using Rebus.Threading;
+using Rebus.Time;
 
 namespace Rebus.SqlServer.Tests.Integration
 {
@@ -26,7 +27,7 @@ namespace Rebus.SqlServer.Tests.Integration
                 .Transport(t => t.Register(c =>
                 {
                     var connectionProvider = new TestConnectionProvider(SqlTestHelper.ConnectionString, activeConnections);
-                    var transport = new SqlServerTransport(connectionProvider, "bimse", c.Get<IRebusLoggerFactory>(), c.Get<IAsyncTaskFactory>());
+                    var transport = new SqlServerTransport(connectionProvider, "bimse", c.Get<IRebusLoggerFactory>(), c.Get<IAsyncTaskFactory>(), c.Get<IRebusTime>());
 
                     transport.EnsureTableIsCreated();
 

--- a/Rebus.SqlServer.Tests/Integration/TestSqlAllTheWay.cs
+++ b/Rebus.SqlServer.Tests/Integration/TestSqlAllTheWay.cs
@@ -5,7 +5,6 @@ using NUnit.Framework;
 using Rebus.Activation;
 using Rebus.Bus;
 using Rebus.Config;
-using Rebus.SqlServer.Transport;
 using Rebus.Tests.Contracts;
 using Rebus.Tests.Contracts.Extensions;
 

--- a/Rebus.SqlServer.Tests/Properties/AssemblyInfo.cs
+++ b/Rebus.SqlServer.Tests/Properties/AssemblyInfo.cs
@@ -1,5 +1,4 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 

--- a/Rebus.SqlServer.Tests/Rebus.SqlServer.Tests.csproj
+++ b/Rebus.SqlServer.Tests/Rebus.SqlServer.Tests.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="microsoft.net.test.sdk" Version="15.9.0" />
     <PackageReference Include="nunit" Version="3.7.1" />
     <PackageReference Include="nunit3testadapter" Version="3.10.0" />
-    <PackageReference Include="rebus" Version="5.0.0" />
+    <PackageReference Include="rebus" Version="6.0.0-b04" />
     <PackageReference Include="rebus.tests.contracts" Version="5.0.0" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net45' OR '$(TargetFramework)' == 'net46'">

--- a/Rebus.SqlServer.Tests/Timeouts/SqlServerTimeoutManagerFactory.cs
+++ b/Rebus.SqlServer.Tests/Timeouts/SqlServerTimeoutManagerFactory.cs
@@ -2,6 +2,7 @@
 using Rebus.Logging;
 using Rebus.SqlServer.Timeouts;
 using Rebus.Tests.Contracts.Timeouts;
+using Rebus.Time;
 using Rebus.Timeouts;
 
 namespace Rebus.SqlServer.Tests.Timeouts
@@ -17,9 +18,10 @@ namespace Rebus.SqlServer.Tests.Timeouts
 
         public ITimeoutManager Create()
         {
+            var rebusTime = new DefaultRebusTime();
             var consoleLoggerFactory = new ConsoleLoggerFactory(true);
             var connectionProvider = new DbConnectionProvider(SqlTestHelper.ConnectionString, consoleLoggerFactory);
-            var timeoutManager = new SqlServerTimeoutManager(connectionProvider, TableName, consoleLoggerFactory);
+            var timeoutManager = new SqlServerTimeoutManager(connectionProvider, TableName, consoleLoggerFactory, rebusTime);
 
             timeoutManager.EnsureTableIsCreated();
 

--- a/Rebus.SqlServer.Tests/Transport/Contract/Factories/SqlLeaseTransportFactory.cs
+++ b/Rebus.SqlServer.Tests/Transport/Contract/Factories/SqlLeaseTransportFactory.cs
@@ -6,6 +6,7 @@ using Rebus.SqlServer.Transport;
 using Rebus.Tests.Contracts;
 using Rebus.Tests.Contracts.Transports;
 using Rebus.Threading.TaskParallelLibrary;
+using Rebus.Time;
 using Rebus.Transport;
 
 namespace Rebus.SqlServer.Tests.Transport.Contract.Factories
@@ -28,12 +29,12 @@ namespace Rebus.SqlServer.Tests.Transport.Contract.Factories
 
             _tablesToDrop.Add(tableName);
 
+            var rebusTime = new DefaultRebusTime();
             var consoleLoggerFactory = new ConsoleLoggerFactory(false);
             var connectionProvider = new DbConnectionProvider(SqlTestHelper.ConnectionString, consoleLoggerFactory);
             var asyncTaskFactory = new TplAsyncTaskFactory(consoleLoggerFactory);
             var transport = new SqlServerLeaseTransport(connectionProvider, null, consoleLoggerFactory,
-                asyncTaskFactory, TimeSpan.FromMinutes(1), TimeSpan.FromSeconds(2), () => Environment.MachineName);
-            //var transport = new SqlServerTransport(connectionProvider, tableName, null, consoleLoggerFactory, asyncTaskFactory);
+                asyncTaskFactory, rebusTime, TimeSpan.FromMinutes(1), TimeSpan.FromSeconds(2), () => Environment.MachineName);
 
             _disposables.Add(transport);
 
@@ -50,13 +51,13 @@ namespace Rebus.SqlServer.Tests.Transport.Contract.Factories
 
             _tablesToDrop.Add(tableName);
 
+            var rebusTime = new DefaultRebusTime();
             var consoleLoggerFactory = new ConsoleLoggerFactory(false);
             var connectionProvider = new DbConnectionProvider(SqlTestHelper.ConnectionString, consoleLoggerFactory);
             var asyncTaskFactory = new TplAsyncTaskFactory(consoleLoggerFactory);
             var transport = new SqlServerLeaseTransport(connectionProvider, inputQueueAddress, consoleLoggerFactory,
-                asyncTaskFactory, TimeSpan.FromMinutes(1), TimeSpan.FromSeconds(2), () => Environment.MachineName);
-//            var transport = new SqlServerTransport(connectionProvider, tableName, inputQueueAddress, consoleLoggerFactory, asyncTaskFactory);
-            
+                asyncTaskFactory, rebusTime, TimeSpan.FromMinutes(1), TimeSpan.FromSeconds(2), () => Environment.MachineName);
+
             _disposables.Add(transport);
             
             transport.EnsureTableIsCreated();

--- a/Rebus.SqlServer.Tests/Transport/Contract/Factories/SqlTransportFactory.cs
+++ b/Rebus.SqlServer.Tests/Transport/Contract/Factories/SqlTransportFactory.cs
@@ -6,6 +6,7 @@ using Rebus.SqlServer.Transport;
 using Rebus.Tests.Contracts;
 using Rebus.Tests.Contracts.Transports;
 using Rebus.Threading.TaskParallelLibrary;
+using Rebus.Time;
 using Rebus.Transport;
 
 namespace Rebus.SqlServer.Tests.Transport.Contract.Factories
@@ -22,10 +23,11 @@ namespace Rebus.SqlServer.Tests.Transport.Contract.Factories
 
         public ITransport CreateOneWayClient()
         {
+            var rebusTime = new DefaultRebusTime();
             var consoleLoggerFactory = new ConsoleLoggerFactory(false);
             var connectionProvider = new DbConnectionProvider(SqlTestHelper.ConnectionString, consoleLoggerFactory);
             var asyncTaskFactory = new TplAsyncTaskFactory(consoleLoggerFactory);
-            var transport = new SqlServerTransport(connectionProvider, null, consoleLoggerFactory, asyncTaskFactory);
+            var transport = new SqlServerTransport(connectionProvider, null, consoleLoggerFactory, asyncTaskFactory, rebusTime);
 
             _disposables.Add(transport);
 
@@ -42,10 +44,11 @@ namespace Rebus.SqlServer.Tests.Transport.Contract.Factories
 
             _tablesToDrop.Add(tableName);
 
+            var rebusTime = new DefaultRebusTime();
             var consoleLoggerFactory = new ConsoleLoggerFactory(false);
             var connectionProvider = new DbConnectionProvider(SqlTestHelper.ConnectionString, consoleLoggerFactory);
             var asyncTaskFactory = new TplAsyncTaskFactory(consoleLoggerFactory);
-            var transport = new SqlServerTransport(connectionProvider, inputQueueAddress, consoleLoggerFactory, asyncTaskFactory);
+            var transport = new SqlServerTransport(connectionProvider, inputQueueAddress, consoleLoggerFactory, asyncTaskFactory, rebusTime);
             
             _disposables.Add(transport);
             

--- a/Rebus.SqlServer.Tests/Transport/TestSqlServerTransport.cs
+++ b/Rebus.SqlServer.Tests/Transport/TestSqlServerTransport.cs
@@ -12,6 +12,7 @@ using Rebus.Messages;
 using Rebus.SqlServer.Transport;
 using Rebus.Tests.Contracts;
 using Rebus.Threading.TaskParallelLibrary;
+using Rebus.Time;
 using Rebus.Transport;
 
 namespace Rebus.SqlServer.Tests.Transport
@@ -27,11 +28,12 @@ namespace Rebus.SqlServer.Tests.Transport
         {
             SqlTestHelper.DropAllTables();
 
+            var rebusTime = new DefaultRebusTime();
             var consoleLoggerFactory = new ConsoleLoggerFactory(false);
             var connectionProvider = new DbConnectionProvider(SqlTestHelper.ConnectionString, consoleLoggerFactory);
             var asyncTaskFactory = new TplAsyncTaskFactory(consoleLoggerFactory);
 
-            _transport = new SqlServerTransport(connectionProvider, QueueName, consoleLoggerFactory, asyncTaskFactory);
+            _transport = new SqlServerTransport(connectionProvider, QueueName, consoleLoggerFactory, asyncTaskFactory, rebusTime);
             _transport.EnsureTableIsCreated();
 
             Using(_transport);

--- a/Rebus.SqlServer.Tests/Transport/TestSqlServerTransportMessageOrdering.cs
+++ b/Rebus.SqlServer.Tests/Transport/TestSqlServerTransportMessageOrdering.cs
@@ -9,6 +9,7 @@ using Rebus.Messages;
 using Rebus.SqlServer.Transport;
 using Rebus.Tests.Contracts;
 using Rebus.Threading.TaskParallelLibrary;
+using Rebus.Time;
 using Rebus.Transport;
 
 namespace Rebus.SqlServer.Tests.Transport
@@ -90,6 +91,7 @@ namespace Rebus.SqlServer.Tests.Transport
 
         static SqlServerTransport GetTransport(TransportType transportType)
         {
+            var rebusTime = new DefaultRebusTime();
             var loggerFactory = new ConsoleLoggerFactory(false);
             var connectionProvider = new DbConnectionProvider(SqlTestHelper.ConnectionString, loggerFactory);
             var asyncTaskFactory = new TplAsyncTaskFactory(loggerFactory);
@@ -100,6 +102,7 @@ namespace Rebus.SqlServer.Tests.Transport
                     QueueName,
                     loggerFactory,
                     asyncTaskFactory,
+                    rebusTime,
                     TimeSpan.FromMinutes(1),
                     TimeSpan.FromSeconds(5),
                     () => "who cares"
@@ -108,7 +111,8 @@ namespace Rebus.SqlServer.Tests.Transport
                     connectionProvider,
                     QueueName,
                     loggerFactory,
-                    asyncTaskFactory
+                    asyncTaskFactory,
+                    rebusTime
                 );
 
             transport.EnsureTableIsCreated();

--- a/Rebus.SqlServer/Config/SqlServerDataBusConfigurationExtensions.cs
+++ b/Rebus.SqlServer/Config/SqlServerDataBusConfigurationExtensions.cs
@@ -4,6 +4,7 @@ using Rebus.DataBus;
 using Rebus.Logging;
 using Rebus.SqlServer;
 using Rebus.SqlServer.DataBus;
+using Rebus.Time;
 
 namespace Rebus.Config
 {
@@ -23,9 +24,10 @@ namespace Rebus.Config
 
             configurer.Register(c =>
             {
+                var rebusTime = c.Get<IRebusTime>();
                 var loggerFactory = c.Get<IRebusLoggerFactory>();
                 var connectionProvider = new DbConnectionProvider(connectionString, loggerFactory, enlistInAmbientTransaction);
-                return new SqlServerDataBusStorage(connectionProvider, tableName, automaticallyCreateTables, loggerFactory, commandTimeout);
+                return new SqlServerDataBusStorage(connectionProvider, tableName, automaticallyCreateTables, loggerFactory, rebusTime, commandTimeout);
             });
         }
 
@@ -40,9 +42,10 @@ namespace Rebus.Config
 
             configurer.Register(c =>
             {
+                var rebusTime = c.Get<IRebusTime>();
                 var loggerFactory = c.Get<IRebusLoggerFactory>();
                 var connectionProvider = new DbConnectionFactoryProvider(connectionFactory, loggerFactory);
-                return new SqlServerDataBusStorage(connectionProvider, tableName, automaticallyCreateTables, loggerFactory, commandTimeout);
+                return new SqlServerDataBusStorage(connectionProvider, tableName, automaticallyCreateTables, loggerFactory, rebusTime, commandTimeout);
             });
         }
     }

--- a/Rebus.SqlServer/Config/SqlServerTimeoutsConfigurationExtensions.cs
+++ b/Rebus.SqlServer/Config/SqlServerTimeoutsConfigurationExtensions.cs
@@ -3,6 +3,7 @@ using System.Threading.Tasks;
 using Rebus.Logging;
 using Rebus.SqlServer;
 using Rebus.SqlServer.Timeouts;
+using Rebus.Time;
 using Rebus.Timeouts;
 
 namespace Rebus.Config
@@ -24,9 +25,10 @@ namespace Rebus.Config
 
             configurer.Register(c =>
             {
+                var rebusTime = c.Get<IRebusTime>();
                 var rebusLoggerFactory = c.Get<IRebusLoggerFactory>();
                 var connectionProvider = new DbConnectionProvider(connectionString, rebusLoggerFactory, enlistInAmbientTransaction);
-                var subscriptionStorage = new SqlServerTimeoutManager(connectionProvider, tableName, rebusLoggerFactory);
+                var subscriptionStorage = new SqlServerTimeoutManager(connectionProvider, tableName, rebusLoggerFactory, rebusTime);
 
                 if (automaticallyCreateTables)
                 {
@@ -49,9 +51,10 @@ namespace Rebus.Config
 
             configurer.Register(c =>
             {
+                var rebusTime = c.Get<IRebusTime>();
                 var rebusLoggerFactory = c.Get<IRebusLoggerFactory>();
                 var connectionProvider = new DbConnectionFactoryProvider(connectionFactory, rebusLoggerFactory);
-                var subscriptionStorage = new SqlServerTimeoutManager(connectionProvider, tableName, rebusLoggerFactory);
+                var subscriptionStorage = new SqlServerTimeoutManager(connectionProvider, tableName, rebusLoggerFactory, rebusTime);
 
                 if (automaticallyCreateTables)
                 {

--- a/Rebus.SqlServer/Config/SqlServerTransportConfigurationExtensions.cs
+++ b/Rebus.SqlServer/Config/SqlServerTransportConfigurationExtensions.cs
@@ -7,6 +7,7 @@ using Rebus.Pipeline.Receive;
 using Rebus.SqlServer;
 using Rebus.SqlServer.Transport;
 using Rebus.Threading;
+using Rebus.Time;
 using Rebus.Timeouts;
 using Rebus.Transport;
 
@@ -104,6 +105,7 @@ namespace Rebus.Config
 
             Configure(configurer, connectionProviderFactory, inputQueueName, (context, provider, inputQueue) =>
             {
+                var rebusTime = context.Get<IRebusTime>();
                 var rebusLoggerFactory = context.Get<IRebusLoggerFactory>();
                 var asyncTaskFactory = context.Get<IAsyncTaskFactory>();
                 return new SqlServerLeaseTransport(
@@ -111,6 +113,7 @@ namespace Rebus.Config
                     inputQueueName,
                     rebusLoggerFactory,
                     asyncTaskFactory,
+                    rebusTime,
                     leaseInterval ?? SqlServerLeaseTransport.DefaultLeaseTime,
                     leaseTolerance ?? SqlServerLeaseTransport.DefaultLeaseTolerance, leasedByFactory,
                     automaticallyRenewLeases
@@ -137,7 +140,7 @@ namespace Rebus.Config
         /// </summary>
         public static void UseSqlServerAsOneWayClient(this StandardConfigurer<ITransport> configurer, string connectionString, bool enlistInAmbientTransaction = false)
         {
-            Configure(configurer, loggerFactory => new DbConnectionProvider(connectionString, loggerFactory, enlistInAmbientTransaction), null, (context, provider, inputQueue) => new SqlServerTransport(provider, inputQueue, context.Get<IRebusLoggerFactory>(), context.Get<IAsyncTaskFactory>()));
+            Configure(configurer, loggerFactory => new DbConnectionProvider(connectionString, loggerFactory, enlistInAmbientTransaction), null, (context, provider, inputQueue) => new SqlServerTransport(provider, inputQueue, context.Get<IRebusLoggerFactory>(), context.Get<IAsyncTaskFactory>(), context.Get<IRebusTime>()));
 
             OneWayClientBackdoor.ConfigureOneWayClient(configurer);
         }
@@ -168,7 +171,7 @@ namespace Rebus.Config
         /// </summary>
         static void Configure(StandardConfigurer<ITransport> configurer, Func<IRebusLoggerFactory, IDbConnectionProvider> connectionProviderFactory, string inputQueueName)
         {
-            Configure(configurer, connectionProviderFactory, inputQueueName, (context, provider, inputQueue) => new SqlServerTransport(provider, inputQueue, context.Get<IRebusLoggerFactory>(), context.Get<IAsyncTaskFactory>()));
+            Configure(configurer, connectionProviderFactory, inputQueueName, (context, provider, inputQueue) => new SqlServerTransport(provider, inputQueue, context.Get<IRebusLoggerFactory>(), context.Get<IAsyncTaskFactory>(), context.Get<IRebusTime>()));
         }
 
         static void Configure(StandardConfigurer<ITransport> configurer, Func<IRebusLoggerFactory, IDbConnectionProvider> connectionProviderFactory, string inputQueueName, TransportFactoryDelegate transportFactory)

--- a/Rebus.SqlServer/Rebus.SqlServer.csproj
+++ b/Rebus.SqlServer/Rebus.SqlServer.csproj
@@ -41,10 +41,10 @@
     <None Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="rebus" Version="5.0.0" />
+    <PackageReference Include="rebus" Version="6.0.0-b04" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
-    <Reference Include="System.Data.Common" />
+	<PackageReference Include="System.Data.Common" Version="4.3.0" />
     <PackageReference Include="System.Data.SqlClient" Version="4.5.0" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net45' OR '$(TargetFramework)' == 'net46'">

--- a/Rebus.SqlServer/SqlServer/DataBus/SqlServerDataBusStorage.cs
+++ b/Rebus.SqlServer/SqlServer/DataBus/SqlServerDataBusStorage.cs
@@ -41,7 +41,7 @@ namespace Rebus.SqlServer.DataBus
             _tableName = TableName.Parse(tableName);
             _ensureTableIsCreated = ensureTableIsCreated;
             _commandTimeout = commandTimeout;
-            _rebusTime = rebusTime ?? throw new ArgumentNullException(nameof(_rebusTime));
+            _rebusTime = rebusTime ?? throw new ArgumentNullException(nameof(rebusTime));
             _log = rebusLoggerFactory.GetLogger<SqlServerDataBusStorage>();
         }
 

--- a/Rebus.SqlServer/SqlServer/DataBus/SqlServerDataBusStorage.cs
+++ b/Rebus.SqlServer/SqlServer/DataBus/SqlServerDataBusStorage.cs
@@ -28,11 +28,12 @@ namespace Rebus.SqlServer.DataBus
         readonly bool _ensureTableIsCreated;
         readonly ILog _log;
         readonly int _commandTimeout ;
+        private readonly IRebusTime _rebusTime;
 
         /// <summary>
         /// Creates the data storage
         /// </summary>
-        public SqlServerDataBusStorage(IDbConnectionProvider connectionProvider, string tableName, bool ensureTableIsCreated, IRebusLoggerFactory rebusLoggerFactory, int commandTimeout)
+        public SqlServerDataBusStorage(IDbConnectionProvider connectionProvider, string tableName, bool ensureTableIsCreated, IRebusLoggerFactory rebusLoggerFactory, IRebusTime rebusTime, int commandTimeout)
         {
             if (tableName == null) throw new ArgumentNullException(nameof(tableName));
             if (rebusLoggerFactory == null) throw new ArgumentNullException(nameof(rebusLoggerFactory));
@@ -40,6 +41,7 @@ namespace Rebus.SqlServer.DataBus
             _tableName = TableName.Parse(tableName);
             _ensureTableIsCreated = ensureTableIsCreated;
             _commandTimeout = commandTimeout;
+            _rebusTime = rebusTime ?? throw new ArgumentNullException(nameof(_rebusTime));
             _log = rebusLoggerFactory.GetLogger<SqlServerDataBusStorage>();
         }
 
@@ -137,7 +139,7 @@ IF NOT EXISTS (SELECT 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = '{_t
         {
             var metadataToWrite = new Dictionary<string, string>(metadata ?? new Dictionary<string, string>())
             {
-                [MetadataKeys.SaveTime] = RebusTime.Now.ToString("O")
+                [MetadataKeys.SaveTime] = _rebusTime.Now.ToString("O")
             };
 
             try
@@ -153,7 +155,7 @@ IF NOT EXISTS (SELECT 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = '{_t
                         command.Parameters.Add("id", SqlDbType.VarChar, 200).Value = id;
                         command.Parameters.Add("meta", SqlDbType.VarBinary, MathUtil.GetNextPowerOfTwo(metadataBytes.Length)).Value = metadataBytes;
                         command.Parameters.Add("data", SqlDbType.VarBinary, MathUtil.GetNextPowerOfTwo((int)source.Length)).Value = source;
-                        command.Parameters.Add("now", SqlDbType.DateTimeOffset).Value = RebusTime.Now;
+                        command.Parameters.Add("now", SqlDbType.DateTimeOffset).Value = _rebusTime.Now;
 
                         await command.ExecuteNonQueryAsync().ConfigureAwait(false);
                     }
@@ -236,7 +238,7 @@ IF NOT EXISTS (SELECT 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = '{_t
             using (var command = connection.CreateCommand())
             {
                 command.CommandText = $"UPDATE {_tableName.QualifiedName} SET [LastReadTime] = @now WHERE [Id] = @id";
-                command.Parameters.Add("now", SqlDbType.DateTimeOffset).Value = RebusTime.Now;
+                command.Parameters.Add("now", SqlDbType.DateTimeOffset).Value = _rebusTime.Now;
                 command.Parameters.Add("id", SqlDbType.VarChar, 200).Value = id;
                 await command.ExecuteNonQueryAsync().ConfigureAwait(false);
             }

--- a/Rebus.SqlServer/SqlServer/Transport/SqlServerLeaseTransport.cs
+++ b/Rebus.SqlServer/SqlServer/Transport/SqlServerLeaseTransport.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using Rebus.Logging;
 using Rebus.Messages;
 using Rebus.Threading;
+using Rebus.Time;
 using Rebus.Transport;
 
 namespace Rebus.SqlServer.Transport
@@ -50,26 +51,28 @@ namespace Rebus.SqlServer.Transport
         readonly Func<string> _leasedByFactory;
 
         /// <summary>
-		/// Constructor
-		/// </summary>
-		/// <param name="connectionProvider">A <see cref="IDbConnection"/> to obtain a database connection</param>
-		/// <param name="inputQueueName">Name of the queue this transport is servicing</param>
-		/// <param name="rebusLoggerFactory">A <seealso cref="IRebusLoggerFactory"/> for building loggers</param>
-		/// <param name="asyncTaskFactory">A <seealso cref="IAsyncTaskFactory"/> for creating periodic tasks</param>
-		/// <param name="leaseInterval">Interval of time messages are leased for</param>
-		/// <param name="leaseTolerance">Buffer to allow lease overruns by</param>
-		/// <param name="leasedByFactory">Factory for generating a string which identifies who has leased a message (eg. A hostname)</param>
-		/// <param name="automaticLeaseRenewalInterval">If non-<c>null</c> messages will be automatically re-leased after this time period has elapsed</param>
-		public SqlServerLeaseTransport(
+        /// Constructor
+        /// </summary>
+        /// <param name="connectionProvider">A <see cref="IDbConnection"/> to obtain a database connection</param>
+        /// <param name="inputQueueName">Name of the queue this transport is servicing</param>
+        /// <param name="rebusLoggerFactory">A <seealso cref="IRebusLoggerFactory"/> for building loggers</param>
+        /// <param name="asyncTaskFactory">A <seealso cref="IAsyncTaskFactory"/> for creating periodic tasks</param>
+        /// <param name="rebusTime">A <seealso cref="IRebusTime"/> to provide the current time</param>
+        /// <param name="leaseInterval">Interval of time messages are leased for</param>
+        /// <param name="leaseTolerance">Buffer to allow lease overruns by</param>
+        /// <param name="leasedByFactory">Factory for generating a string which identifies who has leased a message (eg. A hostname)</param>
+        /// <param name="automaticLeaseRenewalInterval">If non-<c>null</c> messages will be automatically re-leased after this time period has elapsed</param>
+        public SqlServerLeaseTransport(
             IDbConnectionProvider connectionProvider,
             string inputQueueName,
             IRebusLoggerFactory rebusLoggerFactory,
             IAsyncTaskFactory asyncTaskFactory,
+            IRebusTime rebusTime,
             TimeSpan leaseInterval,
             TimeSpan? leaseTolerance,
             Func<string> leasedByFactory,
             TimeSpan? automaticLeaseRenewalInterval = null
-            ) : base(connectionProvider, inputQueueName, rebusLoggerFactory, asyncTaskFactory)
+            ) : base(connectionProvider, inputQueueName, rebusLoggerFactory, asyncTaskFactory, rebusTime)
         {
             _leasedByFactory = leasedByFactory;
             _leaseIntervalMilliseconds = (long)Math.Ceiling(leaseInterval.TotalMilliseconds);


### PR DESCRIPTION
@mookid8000 Hey mogens,

i tried to update the SQL Server transport library to rebus version 6… most of the work should be done.
Unfortunately there is no 'Rebus.Tests.Contracts' package version 6, which is required to complete the update.

Please feel free to pick up this PR and to update the package.

Sincerely,

nolde

---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.
