### PR TITLE
Add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,123 @@
+# To learn more about .editorconfig see https://aka.ms/editorconfigdocs
+############################### 
+# Core EditorConfig Options   # 
+############################### 
+# All files 
+[*] 
+indent_style = space 
+# Code files 
+[*.{cs,csx,vb,vbx}] 
+indent_size = 4 
+insert_final_newline = true 
+charset = utf-8-bom 
+############################### 
+# .NET Coding Conventions     # 
+############################### 
+[*.{cs,vb}] 
+# Organize usings 
+dotnet_sort_system_directives_first = true 
+# this. preferences 
+dotnet_style_qualification_for_field = false:silent 
+dotnet_style_qualification_for_property = false:silent 
+dotnet_style_qualification_for_method = false:silent 
+dotnet_style_qualification_for_event = false:silent 
+# Language keywords vs BCL types preferences 
+dotnet_style_predefined_type_for_locals_parameters_members = true:silent 
+dotnet_style_predefined_type_for_member_access = true:silent 
+# Parentheses preferences 
+dotnet_style_parentheses_in_arithmetic_binary_operators = always_for_clarity:silent 
+dotnet_style_parentheses_in_relational_binary_operators = always_for_clarity:silent 
+dotnet_style_parentheses_in_other_binary_operators = always_for_clarity:silent 
+dotnet_style_parentheses_in_other_operators = never_if_unnecessary:silent 
+# Modifier preferences 
+dotnet_style_require_accessibility_modifiers = for_non_interface_members:silent 
+dotnet_style_readonly_field = true:suggestion 
+# Expression-level preferences 
+dotnet_style_object_initializer = true:suggestion 
+dotnet_style_collection_initializer = true:suggestion 
+dotnet_style_explicit_tuple_names = true:suggestion 
+dotnet_style_null_propagation = true:suggestion 
+dotnet_style_coalesce_expression = true:suggestion 
+dotnet_style_prefer_is_null_check_over_reference_equality_method = true:silent 
+dotnet_prefer_inferred_tuple_names = true:suggestion 
+dotnet_prefer_inferred_anonymous_type_member_names = true:suggestion 
+dotnet_style_prefer_auto_properties = true:silent 
+dotnet_style_prefer_conditional_expression_over_assignment = true:silent 
+dotnet_style_prefer_conditional_expression_over_return = true:silent 
+############################### 
+# Naming Conventions          # 
+############################### 
+# Style Definitions 
+dotnet_naming_style.pascal_case_style.capitalization             = pascal_case 
+# Use PascalCase for constant fields   
+dotnet_naming_rule.constant_fields_should_be_pascal_case.severity = suggestion 
+dotnet_naming_rule.constant_fields_should_be_pascal_case.symbols  = constant_fields 
+dotnet_naming_rule.constant_fields_should_be_pascal_case.style    = pascal_case_style 
+dotnet_naming_symbols.constant_fields.applicable_kinds            = field 
+dotnet_naming_symbols.constant_fields.applicable_accessibilities  = * 
+dotnet_naming_symbols.constant_fields.required_modifiers          = const 
+############################### 
+# C# Coding Conventions       # 
+############################### 
+[*.cs] 
+# var preferences 
+csharp_style_var_for_built_in_types = true:silent 
+csharp_style_var_when_type_is_apparent = true:silent 
+csharp_style_var_elsewhere = true:silent 
+# Expression-bodied members 
+csharp_style_expression_bodied_methods = false:silent 
+csharp_style_expression_bodied_constructors = false:silent 
+csharp_style_expression_bodied_operators = false:silent 
+csharp_style_expression_bodied_properties = true:silent 
+csharp_style_expression_bodied_indexers = true:silent 
+csharp_style_expression_bodied_accessors = true:silent 
+# Pattern matching preferences 
+csharp_style_pattern_matching_over_is_with_cast_check = true:suggestion 
+csharp_style_pattern_matching_over_as_with_null_check = true:suggestion 
+# Null-checking preferences 
+csharp_style_throw_expression = true:suggestion 
+csharp_style_conditional_delegate_call = true:suggestion 
+# Modifier preferences 
+csharp_preferred_modifier_order = public,private,protected,internal,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,volatile,async:suggestion 
+# Expression-level preferences 
+csharp_prefer_braces = true:silent 
+csharp_style_deconstructed_variable_declaration = true:suggestion 
+csharp_prefer_simple_default_expression = true:suggestion 
+csharp_style_pattern_local_over_anonymous_function = true:suggestion 
+csharp_style_inlined_variable_declaration = true:suggestion 
+############################### 
+# C# Formatting Rules         # 
+############################### 
+# New line preferences 
+csharp_new_line_before_open_brace = all 
+csharp_new_line_before_else = true 
+csharp_new_line_before_catch = true 
+csharp_new_line_before_finally = true 
+csharp_new_line_before_members_in_object_initializers = true 
+csharp_new_line_before_members_in_anonymous_types = true 
+csharp_new_line_between_query_expression_clauses = true 
+# Indentation preferences 
+csharp_indent_case_contents = true 
+csharp_indent_switch_labels = true 
+csharp_indent_labels = flush_left 
+# Space preferences 
+csharp_space_after_cast = false 
+csharp_space_after_keywords_in_control_flow_statements = true 
+csharp_space_between_method_call_parameter_list_parentheses = false 
+csharp_space_between_method_declaration_parameter_list_parentheses = false 
+csharp_space_between_parentheses = false 
+csharp_space_before_colon_in_inheritance_clause = true 
+csharp_space_after_colon_in_inheritance_clause = true 
+csharp_space_around_binary_operators = before_and_after 
+csharp_space_between_method_declaration_empty_parameter_list_parentheses = false 
+csharp_space_between_method_call_name_and_opening_parenthesis = false 
+csharp_space_between_method_call_empty_parameter_list_parentheses = false 
+# Wrapping preferences 
+csharp_preserve_single_line_statements = true 
+csharp_preserve_single_line_blocks = true 
+############################### 
+# VB Coding Conventions       # 
+############################### 
+[*.vb] 
+# Modifier preferences 
+visual_basic_preferred_modifier_order = Partial,Default,Private,Protected,Public,Friend,NotOverridable,Overridable,MustOverride,Overloads,Overrides,MustInherit,NotInheritable,Static,Shared,Shadows,ReadOnly,WriteOnly,Dim,Const,WithEvents,Widening,Narrowing,Custom,Async:suggestion 

--- a/Rebus.SqlServer.sln
+++ b/Rebus.SqlServer.sln
@@ -1,6 +1,6 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.25420.1
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.29215.179
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "stuff", "stuff", "{1ABDD7C1-1F8D-402D-8692-3E4B66962DE0}"
 	ProjectSection(SolutionItems) = preProject
@@ -10,9 +10,14 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "stuff", "stuff", "{1ABDD7C1
 		README.md = README.md
 	EndProjectSection
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Rebus.SqlServer", "Rebus.SqlServer\Rebus.SqlServer.csproj", "{FE4FDE82-15A0-4C95-B640-779E8F72E870}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Rebus.SqlServer", "Rebus.SqlServer\Rebus.SqlServer.csproj", "{FE4FDE82-15A0-4C95-B640-779E8F72E870}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Rebus.SqlServer.Tests", "Rebus.SqlServer.Tests\Rebus.SqlServer.Tests.csproj", "{7EFCAF69-991E-4991-A03B-077BE4B9952A}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Rebus.SqlServer.Tests", "Rebus.SqlServer.Tests\Rebus.SqlServer.Tests.csproj", "{7EFCAF69-991E-4991-A03B-077BE4B9952A}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{8B2F7563-E5BE-40CE-B5C5-1882C67230DE}"
+	ProjectSection(SolutionItems) = preProject
+		.editorconfig = .editorconfig
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -31,5 +36,8 @@ Global
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {9EE5BF36-7A6F-49D1-8C96-840BF29144FC}
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
This is the default .Net .editorconfig and probably worthy of some updates to better match the preferred coding style of the repository. But supported editors (Visual Studio, Code, etc) will take it into account when formatting code... helpful to avoid problems with different committers using slightly different styles.

---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.
