### PR TITLE
Generic saga data name handling

### DIFF
--- a/Rebus.SqlServer.Tests/Sagas/SqlServerSagaStorageFactory.cs
+++ b/Rebus.SqlServer.Tests/Sagas/SqlServerSagaStorageFactory.cs
@@ -29,7 +29,8 @@ namespace Rebus.SqlServer.Tests.Sagas
         {
             var consoleLoggerFactory = new ConsoleLoggerFactory(true);
             var connectionProvider = new DbConnectionProvider(SqlTestHelper.ConnectionString, consoleLoggerFactory);
-            var storage = new SqlServerSagaStorage(connectionProvider, DataTableName, IndexTableName, consoleLoggerFactory);
+            var sagaTypeNamingStrategy = new LegacySagaTypeNamingStrategy();
+            var storage = new SqlServerSagaStorage(connectionProvider, DataTableName, IndexTableName, consoleLoggerFactory, sagaTypeNamingStrategy);
 
             storage.EnsureTablesAreCreated();
 

--- a/Rebus.SqlServer.Tests/Sagas/TestSqlServerSagaStorage.cs
+++ b/Rebus.SqlServer.Tests/Sagas/TestSqlServerSagaStorage.cs
@@ -21,6 +21,7 @@ namespace Rebus.SqlServer.Tests.Sagas
         {
             var loggerFactory = new ConsoleLoggerFactory(false);
             _connectionProvider = new DbConnectionProvider(SqlTestHelper.ConnectionString, loggerFactory);
+            var sagaTypeNamingStrategy = new LegacySagaTypeNamingStrategy();
 
             _dataTableName = TestConfig.GetName("sagas");
             _indexTableName = TestConfig.GetName("sagaindex");
@@ -28,7 +29,7 @@ namespace Rebus.SqlServer.Tests.Sagas
             SqlTestHelper.DropTable(_indexTableName);
             SqlTestHelper.DropTable(_dataTableName);
 
-            _storage = new SqlServerSagaStorage(_connectionProvider, _dataTableName, _indexTableName, loggerFactory);
+            _storage = new SqlServerSagaStorage(_connectionProvider, _dataTableName, _indexTableName, loggerFactory, sagaTypeNamingStrategy);
         }
 
         [Test]

--- a/Rebus.SqlServer.Tests/Sagas/TestSqlServerSagaStoragePerformance.cs
+++ b/Rebus.SqlServer.Tests/Sagas/TestSqlServerSagaStoragePerformance.cs
@@ -19,14 +19,15 @@ namespace Rebus.SqlServer.Tests.Sagas
         {
             var loggerFactory = new ConsoleLoggerFactory(false);
             var connectionProvider = new DbConnectionProvider(SqlTestHelper.ConnectionString, loggerFactory);
-
+            var sagaTypeNamingStrategy = new LegacySagaTypeNamingStrategy();
+            
             var dataTableName = TestConfig.GetName("sagas");
             var indexTableName = TestConfig.GetName("sagaindex");
 
             SqlTestHelper.DropTable(indexTableName);
             SqlTestHelper.DropTable(dataTableName);
 
-            _storage = new SqlServerSagaStorage(connectionProvider, dataTableName, indexTableName, loggerFactory);
+            _storage = new SqlServerSagaStorage(connectionProvider, dataTableName, indexTableName, loggerFactory, sagaTypeNamingStrategy);
 
             _storage.EnsureTablesAreCreated();
         }

--- a/Rebus.SqlServer/SqlServer/Sagas/CachedSagaTypeNamingStrategy.cs
+++ b/Rebus.SqlServer/SqlServer/Sagas/CachedSagaTypeNamingStrategy.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Concurrent;
+
+namespace Rebus.SqlServer.Sagas
+{
+    /// <summary>
+    /// Decorator for <seealso cref="ISagaTypeNamingStrategy"/> that caches the results in-case calculations are expensive
+    /// </summary>
+    public class CachedSagaTypeNamingStrategy : ISagaTypeNamingStrategy
+    {
+        private readonly ConcurrentDictionary<Type, string> _sagaTypeCache = new ConcurrentDictionary<Type, string>();
+        private readonly ISagaTypeNamingStrategy _innerSagaTypeNamingStrategy;
+
+        /// <summary>
+        /// Constructs a new instance which will defer actual naming to <paramref name="innerSagaTypeNamingStrategy"/>
+        /// </summary>
+        public CachedSagaTypeNamingStrategy(ISagaTypeNamingStrategy innerSagaTypeNamingStrategy)
+        {
+            _innerSagaTypeNamingStrategy = innerSagaTypeNamingStrategy;
+        }
+
+        /// <inheritdoc />
+        public string GetSagaTypeName(Type sagaDataType, int maximumLength)
+        {
+            return _sagaTypeCache.GetOrAdd(sagaDataType, t => _innerSagaTypeNamingStrategy.GetSagaTypeName(t, maximumLength));
+        }
+    }
+}

--- a/Rebus.SqlServer/SqlServer/Sagas/HumanReadableHashedSagaTypeNamingStrategy.cs
+++ b/Rebus.SqlServer/SqlServer/Sagas/HumanReadableHashedSagaTypeNamingStrategy.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using Rebus.Extensions;
+
+namespace Rebus.SqlServer.Sagas
+{
+    /// <summary>
+    /// Returns a string that uses a portion of the actual saga type name and appends the hash of the simple assembly qualified name of the hash. This is a balance between uniqueness and readable for diagnostic purposes
+    /// </summary>
+    public class HumanReadableHashedSagaTypeNamingStrategy : Sha512SagaTypeNamingStrategy
+    {
+        /// <summary>
+        /// The number of bytes to leave as human readable if no value is specified
+        /// </summary>
+        public const int DefaultHumanReadableBytes = 10;
+
+        private readonly int _numberOfHumanReadableBytes;
+
+        /// <summary>
+        /// Default constructor configured to use <seealso cref="DefaultHumanReadableBytes"/> number of human readable bytes
+        /// </summary>
+        public HumanReadableHashedSagaTypeNamingStrategy() : this(DefaultHumanReadableBytes)
+        {
+        }
+
+        /// <summary>
+        /// Constructs a new instance which uses <paramref name="numberOfHumanReadableBytes"/> of human readable bytes in the output
+        /// </summary>
+        public HumanReadableHashedSagaTypeNamingStrategy(int numberOfHumanReadableBytes)
+        {
+            _numberOfHumanReadableBytes = numberOfHumanReadableBytes;
+        }
+
+        /// <inheritdoc />
+        public override string GetSagaTypeName(Type sagaDataType, int maximumLength)
+        {
+            if (_numberOfHumanReadableBytes > maximumLength)
+            {
+                throw new ArgumentOutOfRangeException(nameof(maximumLength), $"Cannot generate a name of {maximumLength} bytes as {nameof(HumanReadableHashedSagaTypeNamingStrategy)} is configured to use at {_numberOfHumanReadableBytes} human readable bytes");
+            }
+
+            return GenerateHumanReadableHash(sagaDataType.Name, sagaDataType, maximumLength);
+        }
+
+        /// <summary>
+        /// Generates a human readable hash that uses portions of <paramref name="humanReadableName"/> and the hash of <paramref name="sagaDataType"/>
+        /// </summary>
+        protected virtual string GenerateHumanReadableHash(string humanReadableName, Type sagaDataType, int maximumLength)
+        {
+            var humanReadablePortion = humanReadableName.Substring(0, Math.Min(_numberOfHumanReadableBytes, humanReadableName.Length));
+            var simpleName = sagaDataType.GetSimpleAssemblyQualifiedName();
+            var hash = GetBase64EncodedPartialHash(simpleName, maximumLength - humanReadablePortion.Length, System.Text.Encoding.UTF8);
+
+            return $"{humanReadablePortion}{hash}";
+        }
+    }
+}

--- a/Rebus.SqlServer/SqlServer/Sagas/ISagaTypeNamingStrategy.cs
+++ b/Rebus.SqlServer/SqlServer/Sagas/ISagaTypeNamingStrategy.cs
@@ -1,0 +1,18 @@
+﻿using System;
+
+namespace Rebus.SqlServer.Sagas
+{
+    /// <summary>
+    /// A contract for generating a type name for a saga as it'll be stored in the database
+    /// </summary>
+    public interface ISagaTypeNamingStrategy
+    {
+        /// <summary>
+        /// Generate a saga type name. Implementations should be pure/stable; for a given input the output should always be the same as it's used to find the saga in the database
+        /// </summary>
+        /// <param name="sagaDataType">Type a name is to be generated for</param>
+        /// <param name="maximumLength">Maximum allowed length of the result. If the return is longer than this an exception will be thrown</param>
+        /// <returns>A string representation of <paramref name="sagaDataType"/></returns>
+        string GetSagaTypeName(Type sagaDataType, int maximumLength);
+    }
+}

--- a/Rebus.SqlServer/SqlServer/Sagas/LegacySagaTypeNamingStrategy.cs
+++ b/Rebus.SqlServer/SqlServer/Sagas/LegacySagaTypeNamingStrategy.cs
@@ -1,0 +1,16 @@
+﻿using System;
+
+namespace Rebus.SqlServer.Sagas
+{
+    /// <summary>
+    /// Implementation of <seealso cref="ISagaTypeNamingStrategy"/> which uses legacy type naming; simply returning the name of the class
+    /// </summary>
+    public class LegacySagaTypeNamingStrategy : ISagaTypeNamingStrategy
+    {
+        /// <inheritdoc />
+        public string GetSagaTypeName(Type sagaDataType, int maximumLength)
+        {
+            return sagaDataType.Name;
+        }
+    }
+}

--- a/Rebus.SqlServer/SqlServer/Sagas/Sha512SagaTypeNamingStrategy.cs
+++ b/Rebus.SqlServer/SqlServer/Sagas/Sha512SagaTypeNamingStrategy.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Security.Cryptography;
+using System.Text;
+using Rebus.Extensions;
+
+namespace Rebus.SqlServer.Sagas
+{
+    /// <summary>
+    /// Implementation of <seealso cref="ISagaTypeNamingStrategy"/> that uses as many bytes as it can from an SHA2-512 hash to generat ea name
+    /// </summary>
+    /// <remarks>Note: SHA-2 is seemingly safe to truncate <a href="https://crypto.stackexchange.com/questions/161/should-i-use-the-first-or-last-bits-from-a-sha-256-hash/163#163">Reference</a></remarks>
+    public class Sha512SagaTypeNamingStrategy : ISagaTypeNamingStrategy
+    {
+        /// <inheritdoc />
+        public virtual string GetSagaTypeName(Type sagaDataType, int maximumLength)
+        {
+            return GetBase64EncodedPartialHash(sagaDataType.GetSimpleAssemblyQualifiedName(), maximumLength, Encoding.UTF8);
+        }
+
+        /// <summary>
+        /// Returns a string of up to <paramref name="numberOfBytes"/> characters long that represent the Base64 encoded SHA2-512 hash of <paramref name="inputString"/>. The string will be encoded using <paramref name="encoding"/> first
+        /// </summary>
+        protected string GetBase64EncodedPartialHash(string inputString, int numberOfBytes, Encoding encoding)
+        {
+            using (SHA512Managed sha = new SHA512Managed())
+            {
+                var encodedBytes = encoding.GetBytes(inputString);
+                var hashedBytes = sha.ComputeHash(encodedBytes, 0, encodedBytes.Length);
+                var bytesToUseFromHash = GetMaximumBase64EncodedBytesThatFit(Math.Min(numberOfBytes, hashedBytes.Length));
+
+                return Convert.ToBase64String(hashedBytes, 0, bytesToUseFromHash);
+            }
+        }
+
+        /// <summary>
+        /// Returns the number of bytes of bytes that can be encoded in Base64 and still fit in <paramref name="maximumSize"/>
+        /// </summary>
+        private static int GetMaximumBase64EncodedBytesThatFit(int maximumSize) => (int)Math.Floor(0.75f * maximumSize);
+    }
+}


### PR DESCRIPTION
This supersedes #38 to provide improved saga name handling. It is by default backwards compatible with prior versions... otherwise everyone's sagas would break.

Introduces a new `ISagaTypeNamingStrategy` that can be registered in the injector. If one is not registered at the time the `SqlServerSagaStorage`  is constructed then a default, `LegacySagaTypeNamingStrategy` will be used which generates the name as per the existing method (`Type.Name`). However some other versions are provided;
  1. `Sha512SagaTypeNamingStrategy`: Generates a SHA2-512 hash of the types simple assembly qualified name (This means that, for instance, `GenericSagaContainer<SomeUnderlyingType>` will be hashed based on something like `GenericSagaContainer'1[[SomeUnderlyingType]]`. As such, hashes will not clash. Additionally it will take a portion of the hash up to the maximum allowed bytes. According to https://crypto.stackexchange.com/questions/161/should-i-use-the-first-or-last-bits-from-a-sha-256-hash/163#163 this should be safe to do.
 1. `CachedSagaTypeNamingStrategy`: Intended to wrap around another instance of a `ISagaTypeNamingStrategy` so that costly saga type name calculations will only be performed once.
  1. `HumanReadableHashedSagaTypeNamingStrategy`: Extends `Sha512SagaTypeNamingStrategy` so that a portion of the class name is prefixed before the hash. For an input of `SampleProject.DeleteCustomerSaga` it'd generate an output something like `DeleteCustHc2dpZJ/0b4cJEQB8rCqQXPYtheEx` instead of `Hc2dpZJ/0b4cJEQB8rCqQXPYtheEx78Tvgm7o7H` which is a little harder to peek at the database and see what's going on.

Consumers can register their own implementation of `ISagaTypeNamingStrategy` with Injectionist prior to setting up `SqlSagaStorage`.

**WARNING**: Using anything other than the default `LegacySagaTypeNamingStrategy` will break any inflight sagas... migration of sagas to new naming schemes is left as an exercise for the reader 😜

---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.
