### PR TITLE
Introduce Transport Options

### DIFF
--- a/Rebus.SqlServer/Config/SqlServerLeaseTransportOptions.cs
+++ b/Rebus.SqlServer/Config/SqlServerLeaseTransportOptions.cs
@@ -41,7 +41,7 @@ namespace Rebus.Config {
         public TimeSpan? LeaseTolerance { get; set; }
 
         /// <summary>
-        /// If <c>true</c> then workers will automatically renew the lease they have acquired whilst they're still processing the message. This will occur in accordance with <seealso cref="leaseAutoRenewInterval"/>
+        /// If <c>true</c> then workers will automatically renew the lease they have acquired whilst they're still processing the message. This will occur in accordance with <seealso cref="LeaseAutoRenewInterval"/>
         /// </summary>
         public bool AutomaticallyRenewLeases { get; set; }
 

--- a/Rebus.SqlServer/Config/SqlServerLeaseTransportOptions.cs
+++ b/Rebus.SqlServer/Config/SqlServerLeaseTransportOptions.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using System.Threading.Tasks;
+using Rebus.SqlServer;
+using Rebus.SqlServer.Transport;
+
+namespace Rebus.Config {
+    /// <summary>
+    /// Extends <seealso cref="SqlServerTransportOptions"/> with options specific to the <seealso cref="SqlServerLeaseTransport"/>
+    /// </summary>
+    public class SqlServerLeaseTransportOptions : SqlServerTransportOptions
+    {
+        /// <summary>
+        /// Create an instance of the transport with a pre-created <seealso cref="DbConnectionProvider"/>
+        /// </summary>
+        public SqlServerLeaseTransportOptions(IDbConnectionProvider connectionProvider) : base(connectionProvider)
+        {
+        }
+
+        /// <summary>
+        /// Creates an instance of the transport connecting via <paramref name="connectionString"/>
+        /// </summary>
+        public SqlServerLeaseTransportOptions(string connectionString, bool enlistInAmbientTransaction = false) : base(connectionString, enlistInAmbientTransaction)
+        {
+        }
+
+        /// <summary>
+        /// Creates an instance of the transport with utilising an <seealso cref="IDbConnectionProvider"/> factory
+        /// </summary>
+        public SqlServerLeaseTransportOptions(Func<Task<IDbConnection>> connectionFactory) : base(connectionFactory)
+        {
+        }
+
+        /// <summary>
+        /// If <c>null</c> will default to <seealso cref="SqlServerLeaseTransport.DefaultLeaseTime"/>. Specifies how long a worker will request to keep a message. Higher values require less database communication but increase latency of a message being processed if a worker dies
+        /// </summary>
+        public TimeSpan? LeaseInterval { get; set; }
+
+        /// <summary>
+        /// If <c>null</c> will default to <seealso cref="SqlServerLeaseTransport.DefaultLeaseTime"/>. Specifies how long a worker will request to keep a message. Higher values require less database communication but increase latency of a message being processed if a worker dies
+        /// </summary>
+        public TimeSpan? LeaseTolerance { get; set; }
+
+        /// <summary>
+        /// If <c>true</c> then workers will automatically renew the lease they have acquired whilst they're still processing the message. This will occur in accordance with <seealso cref="leaseAutoRenewInterval"/>
+        /// </summary>
+        public bool AutomaticallyRenewLeases { get; set; }
+
+        /// <summary>
+        /// If <c>null</c> defaults to <seealso cref="SqlServerLeaseTransport.DefaultLeaseAutomaticRenewal"/>. Specifies how frequently a lease will be renewed whilst the worker is processing a message. Lower values decrease the chance of other workers processing the same message but increase DB communication. A value 50% of <seealso cref="LeaseInterval"/> should be appropriate
+        /// </summary>
+        public TimeSpan? LeaseAutoRenewInterval { get; set; }
+
+        /// <summary>
+        /// If non-<c>null</c> a factory which returns a string identifying this worker when it leases a message. If <c>null></c> the current machine name is used
+        /// </summary>
+        public Func<string> LeasedByFactory { get; set; }
+    }
+}

--- a/Rebus.SqlServer/Config/SqlServerLeaseTransportOptions.cs
+++ b/Rebus.SqlServer/Config/SqlServerLeaseTransportOptions.cs
@@ -3,7 +3,8 @@ using System.Threading.Tasks;
 using Rebus.SqlServer;
 using Rebus.SqlServer.Transport;
 
-namespace Rebus.Config {
+namespace Rebus.Config
+{
     /// <summary>
     /// Extends <seealso cref="SqlServerTransportOptions"/> with options specific to the <seealso cref="SqlServerLeaseTransport"/>
     /// </summary>
@@ -33,26 +34,26 @@ namespace Rebus.Config {
         /// <summary>
         /// If <c>null</c> will default to <seealso cref="SqlServerLeaseTransport.DefaultLeaseTime"/>. Specifies how long a worker will request to keep a message. Higher values require less database communication but increase latency of a message being processed if a worker dies
         /// </summary>
-        public TimeSpan? LeaseInterval { get; set; }
+        public TimeSpan? LeaseInterval { get; internal set; }
 
         /// <summary>
         /// If <c>null</c> will default to <seealso cref="SqlServerLeaseTransport.DefaultLeaseTime"/>. Specifies how long a worker will request to keep a message. Higher values require less database communication but increase latency of a message being processed if a worker dies
         /// </summary>
-        public TimeSpan? LeaseTolerance { get; set; }
+        public TimeSpan? LeaseTolerance { get; internal set; }
 
         /// <summary>
         /// If <c>true</c> then workers will automatically renew the lease they have acquired whilst they're still processing the message. This will occur in accordance with <seealso cref="LeaseAutoRenewInterval"/>
         /// </summary>
-        public bool AutomaticallyRenewLeases { get; set; }
+        public bool AutomaticallyRenewLeases { get; internal set; }
 
         /// <summary>
         /// If <c>null</c> defaults to <seealso cref="SqlServerLeaseTransport.DefaultLeaseAutomaticRenewal"/>. Specifies how frequently a lease will be renewed whilst the worker is processing a message. Lower values decrease the chance of other workers processing the same message but increase DB communication. A value 50% of <seealso cref="LeaseInterval"/> should be appropriate
         /// </summary>
-        public TimeSpan? LeaseAutoRenewInterval { get; set; }
+        public TimeSpan? LeaseAutoRenewInterval { get; internal set; }
 
         /// <summary>
         /// If non-<c>null</c> a factory which returns a string identifying this worker when it leases a message. If <c>null></c> the current machine name is used
         /// </summary>
-        public Func<string> LeasedByFactory { get; set; }
+        public Func<string> LeasedByFactory { get; internal set; }
     }
 }

--- a/Rebus.SqlServer/Config/SqlServerTransportConfigurationExtensions.cs
+++ b/Rebus.SqlServer/Config/SqlServerTransportConfigurationExtensions.cs
@@ -53,7 +53,7 @@ namespace Rebus.Config
         }
 
         /// <summary>
-        /// Configures Rebus to use SQL Server as its transport. The "queue" specified by <paramref name="inputQueueName"/> will be used when querying for messages.
+        /// Configures Rebus to use SQL Server as its transport
         /// </summary>
         /// <param name="configurer">Static to extend</param>
         /// <param name="transportOptions">Options controlling the transport setup</param>

--- a/Rebus.SqlServer/Config/SqlServerTransportConfigurationExtensions.cs
+++ b/Rebus.SqlServer/Config/SqlServerTransportConfigurationExtensions.cs
@@ -30,30 +30,31 @@ namespace Rebus.Config
         public static SqlServerLeaseTransportOptions UseSqlServerInLeaseMode(this StandardConfigurer<ITransport> configurer, SqlServerLeaseTransportOptions transportOptions, string inputQueueName)
         {
             return Configure(
-                configurer,
-                (context, provider, inputQueue) =>
-                {
-                    if (transportOptions.LeasedByFactory == null)
+                    configurer,
+                    (context, provider, inputQueue) =>
                     {
-                        transportOptions.SetLeasedByFactory(() => Environment.MachineName);
-                    }
+                        if (transportOptions.LeasedByFactory == null)
+                        {
+                            transportOptions.SetLeasedByFactory(() => Environment.MachineName);
+                        }
 
-                    return new SqlServerLeaseTransport(
-                        provider,
-                        transportOptions.InputQueueName,
-                        context.Get<IRebusLoggerFactory>(),
-                        context.Get<IAsyncTaskFactory>(),
-                        context.Get<IRebusTime>(),
-                        transportOptions.LeaseInterval ?? SqlServerLeaseTransport.DefaultLeaseTime,
-                        transportOptions.LeaseTolerance ?? SqlServerLeaseTransport.DefaultLeaseTolerance,
-                        transportOptions.LeasedByFactory,
-                        transportOptions.AutomaticallyRenewLeases
-                            ? (TimeSpan?)null
-                            : transportOptions.LeaseAutoRenewInterval ?? SqlServerLeaseTransport.DefaultLeaseAutomaticRenewal
-                    );
-                },
-                transportOptions
-            );
+                        return new SqlServerLeaseTransport(
+                            provider,
+                            transportOptions.InputQueueName,
+                            context.Get<IRebusLoggerFactory>(),
+                            context.Get<IAsyncTaskFactory>(),
+                            context.Get<IRebusTime>(),
+                            transportOptions.LeaseInterval ?? SqlServerLeaseTransport.DefaultLeaseTime,
+                            transportOptions.LeaseTolerance ?? SqlServerLeaseTransport.DefaultLeaseTolerance,
+                            transportOptions.LeasedByFactory,
+                            transportOptions.AutomaticallyRenewLeases
+                                ? (TimeSpan?)null
+                                : transportOptions.LeaseAutoRenewInterval ?? SqlServerLeaseTransport.DefaultLeaseAutomaticRenewal
+                        );
+                    },
+                    transportOptions
+                )
+                .ReadFrom(inputQueueName);
         }
 
         /// <summary>
@@ -67,30 +68,31 @@ namespace Rebus.Config
         public static SqlServerLeaseTransportOptions UseSqlServerInLeaseModeAsOneWayClient(this StandardConfigurer<ITransport> configurer, SqlServerLeaseTransportOptions transportOptions)
         {
             return Configure(
-                configurer,
-                (context, provider, inputQueue) =>
-                {
-                    if (transportOptions.LeasedByFactory == null)
+                    configurer,
+                    (context, provider, inputQueue) =>
                     {
-                        transportOptions.SetLeasedByFactory(() => Environment.MachineName);
-                    }
+                        if (transportOptions.LeasedByFactory == null)
+                        {
+                            transportOptions.SetLeasedByFactory(() => Environment.MachineName);
+                        }
 
-                    return new SqlServerLeaseTransport(
-                        provider,
-                        transportOptions.InputQueueName,
-                        context.Get<IRebusLoggerFactory>(),
-                        context.Get<IAsyncTaskFactory>(),
-                        context.Get<IRebusTime>(),
-                        transportOptions.LeaseInterval ?? SqlServerLeaseTransport.DefaultLeaseTime,
-                        transportOptions.LeaseTolerance ?? SqlServerLeaseTransport.DefaultLeaseTolerance,
-                        transportOptions.LeasedByFactory,
-                        transportOptions.AutomaticallyRenewLeases
-                            ? (TimeSpan?)null
-                            : transportOptions.LeaseAutoRenewInterval ?? SqlServerLeaseTransport.DefaultLeaseAutomaticRenewal
-                    );
-                },
-                transportOptions
-            ).AsOneWayClient();
+                        return new SqlServerLeaseTransport(
+                            provider,
+                            transportOptions.InputQueueName,
+                            context.Get<IRebusLoggerFactory>(),
+                            context.Get<IAsyncTaskFactory>(),
+                            context.Get<IRebusTime>(),
+                            transportOptions.LeaseInterval ?? SqlServerLeaseTransport.DefaultLeaseTime,
+                            transportOptions.LeaseTolerance ?? SqlServerLeaseTransport.DefaultLeaseTolerance,
+                            transportOptions.LeasedByFactory,
+                            transportOptions.AutomaticallyRenewLeases
+                                ? (TimeSpan?)null
+                                : transportOptions.LeaseAutoRenewInterval ?? SqlServerLeaseTransport.DefaultLeaseAutomaticRenewal
+                        );
+                    },
+                    transportOptions
+                )
+                .AsOneWayClient();
         }
 
         /// <summary>

--- a/Rebus.SqlServer/Config/SqlServerTransportOptions.cs
+++ b/Rebus.SqlServer/Config/SqlServerTransportOptions.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using System.Threading.Tasks;
+using Rebus.Injection;
+using Rebus.Logging;
+using Rebus.SqlServer;
+using Rebus.SqlServer.Transport;
+
+namespace Rebus.Config {
+    /// <summary>
+    /// Describes options used to configure the <seealso cref="SqlServerTransport"/>
+    /// </summary>
+    public class SqlServerTransportOptions
+    {
+        /// <summary>
+        /// Connection provider used to create connections for the transport
+        /// </summary>
+        public Func<IResolutionContext, IDbConnectionProvider> ConnectionProviderFactory { get; }
+
+        /// <summary>
+        /// Name of the input queue to process. If <c>null</c> or whitespace the transport will be configured in one way mode (send only)
+        /// </summary>
+        public string InputQueueName { get; set; }
+
+        /// <summary>
+        /// If <c>true</c> the transport is configured in one way mode
+        /// </summary>
+        public bool IsOneWayQueue => InputQueueName == null;
+
+        /// <summary>
+        /// If <c>false</c> tables will not be created and must be created outside of Rebus
+        /// </summary>
+        public bool EnsureTablesAreCreated { get; set; } = false;
+
+        /// <summary>
+        /// Create an instance of the transport with a pre-created <seealso cref="DbConnectionProvider"/>
+        /// </summary>
+        public SqlServerTransportOptions(IDbConnectionProvider connectionProvider)
+        {
+            ConnectionProviderFactory = (resolutionContext) => connectionProvider;
+        }
+
+        /// <summary>
+        /// Creates an instance of the transport connecting via <paramref name="connectionString"/>
+        /// </summary>
+        public SqlServerTransportOptions(string connectionString, bool enlistInAmbientTransaction = false)
+        {
+            ConnectionProviderFactory = (resolutionContext) => new DbConnectionProvider(connectionString, resolutionContext.Get<IRebusLoggerFactory>(), enlistInAmbientTransaction);
+        }
+
+        /// <summary>
+        /// Creates an instance of the transport with utilising an <seealso cref="IDbConnectionProvider"/> factory
+        /// </summary>
+        public SqlServerTransportOptions(Func<Task<IDbConnection>> connectionFactory)
+        {
+            ConnectionProviderFactory = (resolutionContext) => new DbConnectionFactoryProvider(connectionFactory, resolutionContext.Get<IRebusLoggerFactory>());
+        }
+    }
+}

--- a/Rebus.SqlServer/Config/SqlServerTransportOptions.cs
+++ b/Rebus.SqlServer/Config/SqlServerTransportOptions.cs
@@ -5,32 +5,13 @@ using Rebus.Logging;
 using Rebus.SqlServer;
 using Rebus.SqlServer.Transport;
 
-namespace Rebus.Config {
+namespace Rebus.Config
+{
     /// <summary>
     /// Describes options used to configure the <seealso cref="SqlServerTransport"/>
     /// </summary>
     public class SqlServerTransportOptions
     {
-        /// <summary>
-        /// Connection provider used to create connections for the transport
-        /// </summary>
-        public Func<IResolutionContext, IDbConnectionProvider> ConnectionProviderFactory { get; }
-
-        /// <summary>
-        /// Name of the input queue to process. If <c>null</c> or whitespace the transport will be configured in one way mode (send only)
-        /// </summary>
-        public string InputQueueName { get; set; }
-
-        /// <summary>
-        /// If <c>true</c> the transport is configured in one way mode
-        /// </summary>
-        public bool IsOneWayQueue => InputQueueName == null;
-
-        /// <summary>
-        /// If <c>false</c> tables will not be created and must be created outside of Rebus
-        /// </summary>
-        public bool EnsureTablesAreCreated { get; set; } = false;
-
         /// <summary>
         /// Create an instance of the transport with a pre-created <seealso cref="DbConnectionProvider"/>
         /// </summary>
@@ -54,5 +35,25 @@ namespace Rebus.Config {
         {
             ConnectionProviderFactory = (resolutionContext) => new DbConnectionFactoryProvider(connectionFactory, resolutionContext.Get<IRebusLoggerFactory>());
         }
+
+        /// <summary>
+        /// Connection provider used to create connections for the transport
+        /// </summary>
+        public Func<IResolutionContext, IDbConnectionProvider> ConnectionProviderFactory { get; }
+
+        /// <summary>
+        /// Name of the input queue to process. If <c>null</c> or whitespace the transport will be configured in one way mode (send only)
+        /// </summary>
+        public string InputQueueName { get; internal set; }
+
+        /// <summary>
+        /// If <c>true</c> the transport is configured in one way mode
+        /// </summary>
+        public bool IsOneWayQueue => InputQueueName == null;
+
+        /// <summary>
+        /// If <c>false</c> tables will not be created and must be created outside of Rebus
+        /// </summary>
+        public bool EnsureTablesAreCreated { get; internal set; } = true;
     }
 }

--- a/Rebus.SqlServer/Config/SqlServerTransportOptionsExtensions.cs
+++ b/Rebus.SqlServer/Config/SqlServerTransportOptionsExtensions.cs
@@ -84,7 +84,7 @@ namespace Rebus.Config
         }
 
         /// <summary>
-        /// Disables automatic lease renewal. Message handlers that run longer than <seealso cref="LeaseInterval"/> would be processed by another worker even if the worker processing this message is healthy
+        /// Disables automatic lease renewal. Message handlers that run longer than <seealso cref="SqlServerLeaseTransportOptions.LeaseInterval"/> would be processed by another worker even if the worker processing this message is healthy
         /// </summary>
         public static TLeaseTransportOptions DisableAutomaticLeaseRenewal<TLeaseTransportOptions>(this TLeaseTransportOptions options) where TLeaseTransportOptions : SqlServerLeaseTransportOptions
         {

--- a/Rebus.SqlServer/Config/SqlServerTransportOptionsExtensions.cs
+++ b/Rebus.SqlServer/Config/SqlServerTransportOptionsExtensions.cs
@@ -1,0 +1,105 @@
+﻿using System;
+using Rebus.SqlServer.Transport;
+
+namespace Rebus.Config
+{
+    /// <summary>
+    /// Provides extensions for managing <seealso cref="SqlServerTransportOptions"/>
+    /// </summary>
+    public static class SqlServerTransportOptionsExtensions
+    {
+        /// <summary>
+        /// Flags the transport as only being used for sending
+        /// </summary>
+        public static TTransportOptions AsOneWayClient<TTransportOptions>(this TTransportOptions options) where TTransportOptions : SqlServerTransportOptions
+        {
+            options.InputQueueName = null;
+            return options;
+        }
+
+        /// <summary>
+        /// Configures teh transport to read from <paramref name="inputQueueName"/>
+        /// </summary>
+        public static TTransportOptions ReadFrom<TTransportOptions>(this TTransportOptions options, string inputQueueName) where TTransportOptions : SqlServerTransportOptions
+        {
+            options.InputQueueName = inputQueueName;
+            return options;
+        }
+
+        /// <summary>
+        /// Opts the client out of any table creation
+        /// </summary>
+        public static TTransportOptions OptOutOfTableCreation<TTransportOptions>(this TTransportOptions options) where TTransportOptions : SqlServerTransportOptions
+        {
+            options.EnsureTablesAreCreated = false;
+            return options;
+        }
+
+        /// <summary>
+        /// Sets if table creation is allowed
+        /// </summary>
+        public static TTransportOptions SetEnsureTablesAreCreated<TTransportOptions>(this TTransportOptions options, bool ensureTablesAreCreated) where TTransportOptions : SqlServerTransportOptions
+        {
+            options.EnsureTablesAreCreated = ensureTablesAreCreated;
+            return options;
+        }
+
+        /// <summary>
+        /// If <c>null</c> will default to <seealso cref="SqlServerLeaseTransport.DefaultLeaseTime"/>. Specifies how long a worker will request to keep a message. Higher values require less database communication but increase latency of a message being processed if a worker dies
+        /// </summary>
+        public static TLeaseTransportOptions SetLeaseInterval<TLeaseTransportOptions>(this TLeaseTransportOptions options, TimeSpan? leaseInterval) where TLeaseTransportOptions : SqlServerLeaseTransportOptions
+        {
+            options.LeaseInterval = leaseInterval;
+            return options;
+        }
+
+        /// <summary>
+        /// If <c>null</c> will default to <seealso cref="SqlServerLeaseTransport.DefaultLeaseTime"/>. Specifies how long a worker will request to keep a message. Higher values require less database communication but increase latency of a message being processed if a worker dies
+        /// </summary>
+        public static TLeaseTransportOptions SetLeaseTolerance<TLeaseTransportOptions>(this TLeaseTransportOptions options, TimeSpan? leaseTolerance) where TLeaseTransportOptions : SqlServerLeaseTransportOptions
+        {
+            options.LeaseTolerance = leaseTolerance;
+            return options;
+        }
+
+        /// <summary>
+        /// Enables or disables automatic lease renewal. If <paramref name="automaticallyRenewLeases"/> is <c>true</c> and <paramref name="automaticLeaseRenewInterval"/> is <c>null</c> it will default to <seealso cref="SqlServerLeaseTransport.DefaultLeaseAutomaticRenewal"/>
+        /// </summary>
+        public static TLeaseTransportOptions SetAutomaticLeaseRenewal<TLeaseTransportOptions>(this TLeaseTransportOptions options, bool automaticallyRenewLeases, TimeSpan? automaticLeaseRenewInterval) where TLeaseTransportOptions : SqlServerLeaseTransportOptions
+        {
+            options.AutomaticallyRenewLeases = automaticallyRenewLeases;
+            options.LeaseAutoRenewInterval = automaticLeaseRenewInterval;
+            return options;
+        }
+
+
+        /// <summary>
+        /// Enables automatic lease renewal. If <paramref name="automaticLeaseRenewInterval"/> is <c>null</c> then <seealso cref="SqlServerLeaseTransport.DefaultLeaseAutomaticRenewal"/> will be used instead
+        /// </summary>
+        public static TLeaseTransportOptions EnableAutomaticLeaseRenewal<TLeaseTransportOptions>(this TLeaseTransportOptions options, TimeSpan? automaticLeaseRenewInterval) where TLeaseTransportOptions : SqlServerLeaseTransportOptions
+        {
+            options.AutomaticallyRenewLeases = true;
+            options.LeaseAutoRenewInterval = automaticLeaseRenewInterval;
+            return options;
+        }
+
+        /// <summary>
+        /// Disables automatic lease renewal. Message handlers that run longer than <seealso cref="LeaseInterval"/> would be processed by another worker even if the worker processing this message is healthy
+        /// </summary>
+        public static TLeaseTransportOptions DisableAutomaticLeaseRenewal<TLeaseTransportOptions>(this TLeaseTransportOptions options) where TLeaseTransportOptions : SqlServerLeaseTransportOptions
+        {
+            options.AutomaticallyRenewLeases = false;
+            options.LeaseAutoRenewInterval = null;
+            return options;
+        }
+
+        /// <summary>
+        /// If non-<c>null</c> a factory which returns a string identifying this worker when it leases a message. If <c>null></c> the current machine name is used
+        /// </summary>
+        public static TLeaseTransportOptions SetLeasedByFactory<TLeaseTransportOptions>(this TLeaseTransportOptions options, Func<string> leasedByFactory) where TLeaseTransportOptions : SqlServerLeaseTransportOptions
+        {
+            options.LeasedByFactory = leasedByFactory;
+            return options;
+        }
+    }
+}

--- a/Rebus.SqlServer/SqlServer/Transport/SqlServerLeaseTransport.cs
+++ b/Rebus.SqlServer/SqlServer/Transport/SqlServerLeaseTransport.cs
@@ -179,27 +179,28 @@ OUTPUT	inserted.*";
         /// <summary>
         /// Provides an oppurtunity for derived implementations to also update the schema
         /// </summary>
-        protected override string AdditionalSchemaModifications()
+        /// <param name="tableName"></param>
+        protected override string AdditionalSchemaModifications(TableName tableName)
         {
             return $@"
-IF NOT EXISTS (SELECT 1 FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA = '{ReceiveTableName.Schema}' AND TABLE_NAME = '{ReceiveTableName.Name}' AND COLUMN_NAME = 'leaseduntil')
+IF NOT EXISTS (SELECT 1 FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA = '{tableName.Schema}' AND TABLE_NAME = '{tableName.Name}' AND COLUMN_NAME = 'leaseduntil')
 BEGIN
-	ALTER TABLE {ReceiveTableName.QualifiedName} ADD leaseduntil datetime2 null
+	ALTER TABLE {tableName.QualifiedName} ADD leaseduntil datetime2 null
 END
 
 ----
 
-IF NOT EXISTS (SELECT 1 FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA = '{ReceiveTableName.Schema}' AND TABLE_NAME = '{ReceiveTableName.Name}' AND COLUMN_NAME = 'leasedby')
+IF NOT EXISTS (SELECT 1 FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA = '{tableName.Schema}' AND TABLE_NAME = '{tableName.Name}' AND COLUMN_NAME = 'leasedby')
 BEGIN
-	ALTER TABLE {ReceiveTableName.QualifiedName} ADD leasedby nvarchar({LeasedByColumnSize}) null
+	ALTER TABLE {tableName.QualifiedName} ADD leasedby nvarchar({LeasedByColumnSize}) null
 END
 
 
 ----
 
-IF NOT EXISTS (SELECT 1 FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA = '{ReceiveTableName.Schema}' AND TABLE_NAME = '{ReceiveTableName.Name}' AND COLUMN_NAME = 'leasedat')
+IF NOT EXISTS (SELECT 1 FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA = '{tableName.Schema}' AND TABLE_NAME = '{tableName.Name}' AND COLUMN_NAME = 'leasedat')
 BEGIN
-	ALTER TABLE {ReceiveTableName.QualifiedName} ADD leasedat datetime2 null
+	ALTER TABLE {tableName.QualifiedName} ADD leasedat datetime2 null
 END
 
 ";

--- a/Rebus.SqlServer/SqlServer/Transport/SqlServerTransport.cs
+++ b/Rebus.SqlServer/SqlServer/Transport/SqlServerTransport.cs
@@ -208,16 +208,17 @@ IF NOT EXISTS (SELECT 1 FROM sys.indexes WHERE name = '{expirationIndexName}')
 
 ");
 
-                var additional = AdditionalSchemaModifications();
+                var additional = AdditionalSchemaModifications(tableName);
                 ExecuteCommands(connection, additional);
                 await connection.Complete();
             }
         }
 
         /// <summary>
-        /// Provides an oppurtunity for derived implementations to also update the schema
+        /// Provides an opportunity for derived implementations to also update the schema
         /// </summary>
-        protected virtual string AdditionalSchemaModifications()
+        /// <param name="tableName">Name of the table to create schema modifications for</param>
+        protected virtual string AdditionalSchemaModifications(TableName tableName)
         {
             return string.Empty;
         }


### PR DESCRIPTION
The existing many-different-ways of configuring the transports was getting difficult to maintain and missed some combinations. This PR introduces two new classes; `SqlServerTransportOptions` (for configuring `SqlServerTransport`) and `SqlServerLeaseTransportOptions` (for configuring `SqlServerLeaseTransportOptions`). Existing methods have been refactored, but left as is, and marked as obsolete for future removal.

Example uses;
```
config.Transport(
  c => {
    c.UseSqlServerInLeaseMode(
      new SqlServerServerLeaseTransportOptions(dbFactoryFunction) {
      InputQueueName = "InputMessages",
      EnsureTablesAreCreated = false,
      LeaseInterval = TimeSpan.FromSeconds(60)
  }
);
```

Or to create a one way client that uses the normal SQL Server transport;
```
config.Transport(
  c => {
    c.UseSqlServer(
      new SqlServerServerTransportOptions(dbConnectionProvider) {
      InputQueueName = null,
  }
);
```

I'm not sure if you want to promote one way mode to a "first class citizen" like it currently is... if so, I'd basically just have those overloads call through pre-configured. Eg.

```
public void UseSqlServerInLeaseModeAsOneWayClient(this StandardConfigurer<ITransport> configurer, SqlServerLeaseTransportOptions transportOptions) {
  transportOptions.InputQueueName = null;
  configurer.UseSqlServerInLeaseMode(transportOptions);
}
```

But I erred on the side of (eventually) trying to limit the number of overloads.

The other option I played with is the idea of having an option builder... but found it felt like a lot of ceremony. Eg.

```
config.Transport(
  c => {
    SqlServerTransportOptionsBuilder builder = new SqlServerTransportOptionsBuilder();
    SqlServerTransportOptions options = builder
      .WithConnection(someDatabaseConnectionString)
      .AsOneWayClient()
      .SkipTableCreation()
      .Build();

    c.UseSqlServer(options)
  }
);
```

---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.
