### PR TITLE
Improve index usefulness for dequeuing messages with large backlogs

### DIFF
--- a/Rebus.SqlServer/SqlServer/Transport/SqlServerLeaseTransport.cs
+++ b/Rebus.SqlServer/SqlServer/Transport/SqlServerLeaseTransport.cs
@@ -213,7 +213,7 @@ END
 -- We can find this by looking for the index with priority as is_descending_key = 0
 IF EXISTS (SELECT 1 FROM sys.indexes I JOIN sys.index_columns IC ON I.object_id = OBJECT_ID('{tableName.QualifiedName}') AND I.name = '{receiveIndexName}' AND IC.object_id = I.object_id AND IC.index_id = I.index_id JOIN sys.columns C ON C.object_id = IC.object_id AND C.column_id = IC.column_id AND C.name = 'priority' and IC.is_descending_key = 0)
 BEGIN
-    DROP INDEX {receiveIndexName} ON {tableName.QualifiedName}
+    DROP INDEX [{receiveIndexName}] ON {tableName.QualifiedName}
 END
 
 ----


### PR DESCRIPTION
Prior index was (Priority, Visible, Expiration, LeasedUntil, Id). New index is (Priority DESC, Visible, Id, Expiration, LeasedUntil) which matches the dequeue query for the lease transport better.

Using the performance test unit test:

Before;
1000: 565 messages/s
10000: 285 messages/s

After;
1000: 362 messages/s
10000: 247 messages/s

However in our real world performance testing using 40 VMs processing a backlog of 64,000 messages (all with a visible time of now) we observed a 50% decrease in resources required with this index applied. Your mileage may vary, however... 🧐

One thing I noticed looking at the query plan of before/after is that before would require an index scan of however many messages were in the queue. Where as after the new index it could do an index seek. This meant for our 64k backlog scenario before required 64,000 scans and several hundred logical reads and after required 1 seek and a handful of logical reads.

---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.
