### PR TITLE
Timestamp handling improvements

### DIFF
--- a/Rebus.SqlServer/SqlServer/Transport/SqlServerLeaseTransport.cs
+++ b/Rebus.SqlServer/SqlServer/Transport/SqlServerLeaseTransport.cs
@@ -131,11 +131,11 @@ namespace Rebus.SqlServer.Transport
 			[leaseduntil],
 			[leasedby]
 	FROM	{ReceiveTableName.QualifiedName} M WITH (ROWLOCK, READPAST, READCOMMITTEDLOCK)
-	WHERE	M.[visible] < getdate()
-	AND		M.[expiration] > getdate()
+	WHERE	M.[visible] < sysdatetimeoffset()
+	AND		M.[expiration] > sysdatetimeoffset()
 	AND		1 = CASE
 					WHEN M.[leaseduntil] is null then 1
-					WHEN DATEADD(ms, @leasetolerancemilliseconds, M.[leaseduntil]) < getdate() THEN 1
+					WHEN DATEADD(ms, @leasetolerancemilliseconds, M.[leaseduntil]) < sysdatetimeoffset() THEN 1
 					ELSE 0
 				END
 	ORDER
@@ -144,8 +144,8 @@ namespace Rebus.SqlServer.Transport
 			[id] ASC
 )
 UPDATE	TopCTE WITH (ROWLOCK, READCOMMITTEDLOCK)
-SET		[leaseduntil] = DATEADD(ms, @leasemilliseconds, getdate()),
-		[leasedat] = getdate(),
+SET		[leaseduntil] = DATEADD(ms, @leasemilliseconds, sysdatetimeoffset()),
+		[leasedat] = sysdatetimeoffset(),
 		[leasedby] = @leasedby
 OUTPUT	inserted.*";
                     selectCommand.Parameters.Add("@leasemilliseconds", SqlDbType.BigInt).Value = _leaseIntervalMilliseconds;
@@ -344,7 +344,7 @@ WHERE	id = @id
 UPDATE	{tableName} WITH (ROWLOCK)
 SET		leaseduntil =	CASE
 							WHEN @leaseintervalmilliseconds IS NULL THEN NULL
-							ELSE dateadd(ms, @leaseintervalmilliseconds, getdate())
+							ELSE dateadd(ms, @leaseintervalmilliseconds, sysdatetimeoffset())
 						END,
 		leasedby	=	CASE
 							WHEN @leaseintervalmilliseconds IS NULL THEN NULL

--- a/Rebus.SqlServer/SqlServer/Transport/SqlServerTransport.cs
+++ b/Rebus.SqlServer/SqlServer/Transport/SqlServerTransport.cs
@@ -304,8 +304,8 @@ IF NOT EXISTS (SELECT 1 FROM sys.indexes WHERE name = '{expirationIndexName}')
 				[body]
 		FROM	{ReceiveTableName.QualifiedName} M WITH (ROWLOCK, READPAST, READCOMMITTEDLOCK)
 		WHERE	
-                M.[visible] < getdate()
-		AND		M.[expiration] > getdate()
+                M.[visible] < sysdatetimeoffset()
+		AND		M.[expiration] > sysdatetimeoffset()
 		ORDER
 		BY		[priority] DESC,
 				[visible] ASC,
@@ -400,8 +400,8 @@ VALUES
     @headers,
     @body,
     @priority,
-    dateadd(ss, @visible, getdate()),
-    dateadd(ss, @ttlseconds, getdate())
+    dateadd(ss, @visible, sysdatetimeoffset()),
+    dateadd(ss, @ttlseconds, sysdatetimeoffset())
 )";
 
                 var headers = message.Headers.Clone();
@@ -468,7 +468,7 @@ VALUES
 ;with TopCTE as (
 	SELECT TOP 1 [id] FROM {ReceiveTableName.QualifiedName} WITH (ROWLOCK, READPAST)
 				WHERE 
-                    [expiration] < getdate()
+                    [expiration] < sysdatetimeoffset()
 )
 DELETE FROM TopCTE
 ";

--- a/Rebus.SqlServer/SqlServer/Transport/SqlServerTransport.cs
+++ b/Rebus.SqlServer/SqlServer/Transport/SqlServerTransport.cs
@@ -400,15 +400,15 @@ VALUES
     @headers,
     @body,
     @priority,
-    dateadd(ss, @visible, sysdatetimeoffset()),
-    dateadd(ss, @ttlseconds, sysdatetimeoffset())
+    dateadd(ms, @visibilemilliseconds, dateadd(ss, @visibiletotalseconds, sysdatetimeoffset())),
+    dateadd(ms, @ttlmilliseconds, dateadd(ss, @ttltotalseconds, sysdatetimeoffset()))
 )";
 
                 var headers = message.Headers.Clone();
 
                 var priority = GetMessagePriority(headers);
-                var initialVisibilityDelay = GetInitialVisibilityDelay(headers);
-                var ttlSeconds = GetTtlSeconds(headers);
+                var visible = GetInitialVisibilityDelay(headers);
+                var ttl = GetTtl(headers);
 
                 // must be last because the other functions on the headers might change them
                 var serializedHeaders = HeaderSerializer.Serialize(headers);
@@ -416,38 +416,43 @@ VALUES
                 command.Parameters.Add("headers", SqlDbType.VarBinary, MathUtil.GetNextPowerOfTwo(serializedHeaders.Length)).Value = serializedHeaders;
                 command.Parameters.Add("body", SqlDbType.VarBinary, MathUtil.GetNextPowerOfTwo(message.Body.Length)).Value = message.Body;
                 command.Parameters.Add("priority", SqlDbType.Int).Value = priority;
-                command.Parameters.Add("ttlseconds", SqlDbType.Int).Value = ttlSeconds;
-                command.Parameters.Add("visible", SqlDbType.Int).Value = initialVisibilityDelay;
+                command.Parameters.Add("visibiletotalseconds", SqlDbType.Int).Value = (int)visible.TotalSeconds;
+                command.Parameters.Add("visibilemilliseconds", SqlDbType.Int).Value = visible.Milliseconds;
+                command.Parameters.Add("ttltotalseconds", SqlDbType.Int).Value = (int)ttl.TotalSeconds;
+                command.Parameters.Add("ttlmilliseconds", SqlDbType.Int).Value = ttl.Milliseconds;
 
                 await command.ExecuteNonQueryAsync().ConfigureAwait(false);
             }
         }
 
-        int GetInitialVisibilityDelay(IDictionary<string, string> headers)
+        TimeSpan GetInitialVisibilityDelay(IDictionary<string, string> headers)
         {
             if (!headers.TryGetValue(Headers.DeferredUntil, out var deferredUntilDateTimeOffsetString))
             {
-                return 0;
+                return TimeSpan.Zero;
             }
 
             var deferredUntilTime = deferredUntilDateTimeOffsetString.ToDateTimeOffset();
 
             headers.Remove(Headers.DeferredUntil);
 
-            return (int)(deferredUntilTime - _rebusTime.Now).TotalSeconds;
+            var visibilityDelay = deferredUntilTime - _rebusTime.Now;
+            return visibilityDelay;
         }
 
-        static int GetTtlSeconds(IReadOnlyDictionary<string, string> headers)
+        static TimeSpan GetTtl(IReadOnlyDictionary<string, string> headers)
         {
             const int defaultTtlSecondsAbout60Years = int.MaxValue;
 
             if (!headers.ContainsKey(Headers.TimeToBeReceived))
-                return defaultTtlSecondsAbout60Years;
+            {
+                return TimeSpan.FromSeconds(defaultTtlSecondsAbout60Years);
+            }
 
             var timeToBeReceivedStr = headers[Headers.TimeToBeReceived];
             var timeToBeReceived = TimeSpan.Parse(timeToBeReceivedStr);
 
-            return (int)timeToBeReceived.TotalSeconds;
+            return timeToBeReceived;
         }
 
         async Task PerformExpiredMessagesCleanupCycle()


### PR DESCRIPTION
---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.

---

The changes I made in the PR:

**(1.) Changed from `GETDATE` to `SYSDATETIMEOFFSET`.** 

`GETDATE` is the incorrect function to be used with values that have `datetimeoffset` type (as do the columns in the transport tables). `GETDATE` returns a value of `datetime` which gets converted by SQL Server into `datetimeoffset`. But by doing so, it loses information about the timezone. This means that the timestamps stored will end up incorrect (they'll be stored with the UTC offset, even though they `GETDATE` returns local offset time).

**(2.) Improved the precision of *visibility delay* and *TTL* from seconds to milliseconds.** 

With the previous second-level precision, it sometimes happened that the deferred messages were dispatched almost a second earlier than they should be. With the millisecond precision, the deferred messages get dispatched more accurately.

During the implementation of this, I noticed that the `DATEADD` function has a limit in the *number* parameter, which is the maximum value of `INT` (2147483647). With seconds, we can add up to 68.05 years of range. With milliseconds, this would be only 24.86 days. So I decided to pass the time span as two `INT` values `TotalSeconds` (ranging from 0 to 2147483647) and `Milliseconds` (ranging from 0 to 999). This way, we're able to overcome this limitation.

**(3.) Updated the time span handling in `SqlServerLeaseTransport` to match the handling in `SqlServerTransport`.** 

The `SqlServerLeaseTransport` used to pass `BIGINT` values into the `DATEADD` function, but `DATEADD` only actually supports the range of `INT`. I change the handling so that it will pass two separate `INT` parameters (one for total seconds, one for 0-999 milliseconds) to overcome this limitation. I think this will work better and it's now the same approach that I used in `SqlServerTransport`, which makes it more uniform.

---

Each of these changes was made in a separate commit.

I can explain the reasoning behind some of the changes in more detail if it's not clear, or change something if you're not happy with the code.

Some related information is in here: https://github.com/rebus-org/Rebus.SqlServer/issues/48#issuecomment-513179548