### PR TITLE
Implement autoDeleteQueue option for SqlServer transport. 

### DIFF
--- a/Rebus.SqlServer.Tests/Transport/TestSqlServerTransportAutoDelete.cs
+++ b/Rebus.SqlServer.Tests/Transport/TestSqlServerTransportAutoDelete.cs
@@ -1,0 +1,39 @@
+﻿using System.Linq;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Rebus.Activation;
+using Rebus.Config;
+using Rebus.Logging;
+using Rebus.Tests.Contracts;
+
+namespace Rebus.SqlServer.Tests.Transport
+{
+	[TestFixture, Category(Categories.SqlServer)]
+	public class TestSqlServerTransportAutoDelete : FixtureBase
+    {
+        protected override void SetUp()
+        {
+            SqlTestHelper.DropAllTables();
+        }
+
+        [Test]
+        public async Task Dispose_WhenAutoDeleteQueueEnabled_DropsInputQueue()
+        {
+            var consoleLoggerFactory = new ConsoleLoggerFactory(false);
+            var connectionProvider = new DbConnectionProvider(SqlTestHelper.ConnectionString, consoleLoggerFactory);
+
+            const string queueName = "input";
+            
+            var options = new SqlServerTransportOptions(SqlTestHelper.ConnectionString);
+
+            Configure.With(new BuiltinHandlerActivator())
+                .Logging(l => l.Use(consoleLoggerFactory))
+                .Transport(t => t.UseSqlServer(options, queueName).SetAutoDeleteQueue(true));
+            
+            using (var connection = await connectionProvider.GetConnection())
+            {
+                Assert.False(connection.GetTableNames().Contains(TableName.Parse(queueName)));
+            }
+        }
+    }
+}

--- a/Rebus.SqlServer/Config/SqlServerTransportOptions.cs
+++ b/Rebus.SqlServer/Config/SqlServerTransportOptions.cs
@@ -57,6 +57,11 @@ namespace Rebus.Config
         public bool EnsureTablesAreCreated { get; internal set; } = true;
 
         /// <summary>
+        /// If true, the input queue table will be automatically dropped on transport disposal
+        /// </summary>
+        public bool AutoDeleteQueue { get; internal set; } = false;
+
+        /// <summary>
         /// Gets the delay between executions of the background cleanup task
         /// </summary>
         internal TimeSpan? ExpiredMessagesCleanupInterval { get; set; }

--- a/Rebus.SqlServer/Config/SqlServerTransportOptionsExtensions.cs
+++ b/Rebus.SqlServer/Config/SqlServerTransportOptionsExtensions.cs
@@ -45,6 +45,15 @@ namespace Rebus.Config
         }
 
         /// <summary>
+        /// Sets if table will be dropped automatically
+        /// </summary>
+        public static TTransportOptions SetAutoDeleteQueue<TTransportOptions>(this TTransportOptions options, bool autoDeleteQueue) where TTransportOptions : SqlServerTransportOptions
+        {
+            options.AutoDeleteQueue = autoDeleteQueue;
+            return options;
+        }
+        
+        /// <summary>
         /// Sets the delay between executions of the background cleanup task
         /// </summary>
         public static TTransportOptions SetExpiredMessagesCleanupInterval<TTransportOptions>(this TTransportOptions options, TimeSpan interval) where TTransportOptions : SqlServerTransportOptions


### PR DESCRIPTION
It's useful for transient queues in Rebus.SignalR backplane (https://github.com/rebus-org/Rebus.SignalR/issues/3)

---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.
