### PR TITLE
Feature/code cleanups

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -16,6 +16,7 @@ charset = utf-8-bom
 [*.{cs,vb}] 
 # Organize usings 
 dotnet_sort_system_directives_first = true 
+dotnet_separate_import_directive_groups = false
 # this. preferences 
 dotnet_style_qualification_for_field = false:silent 
 dotnet_style_qualification_for_property = false:silent 

--- a/Rebus.SqlServer.Tests/Bugs/TestBugWhenSendingMessagesInParallel.cs
+++ b/Rebus.SqlServer.Tests/Bugs/TestBugWhenSendingMessagesInParallel.cs
@@ -48,7 +48,7 @@ namespace Rebus.SqlServer.Tests.Bugs
 
             var bus = Configure.With(activator)
                 .Logging(l => l.ColoredConsole(minLevel: LogLevel.Info))
-                .Transport(t => t.UseSqlServer(SqlTestHelper.ConnectionString, inputQueueName))
+                .Transport(t => t.UseSqlServer(new SqlServerTransportOptions(SqlTestHelper.ConnectionString), inputQueueName))
                 .Subscriptions(s => s.StoreInSqlServer(SqlTestHelper.ConnectionString, _subscriptionsTableName, isCentralized: true))
                 .Start();
 

--- a/Rebus.SqlServer.Tests/Bugs/TestBugWhenSendingMessagesInParallel.cs
+++ b/Rebus.SqlServer.Tests/Bugs/TestBugWhenSendingMessagesInParallel.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Concurrent;
 using System.Linq;
 using System.Threading.Tasks;
@@ -18,7 +18,6 @@ namespace Rebus.SqlServer.Tests.Bugs
     public class TestBugWhenSendingMessagesInParallel : FixtureBase
     {
         readonly string _subscriptionsTableName = "subscriptions" + TestConfig.Suffix;
-        readonly string _messagesTableName = "messages" + TestConfig.Suffix;
 
         IBus _bus1;
         IBus _bus2;

--- a/Rebus.SqlServer.Tests/Bugs/TestConcurrencyAndSnapshotIsolation.cs
+++ b/Rebus.SqlServer.Tests/Bugs/TestConcurrencyAndSnapshotIsolation.cs
@@ -52,21 +52,19 @@ namespace Rebus.SqlServer.Tests.Bugs
                 await scope.CompleteAsync();
             }
 
-            using (var scope1 = new RebusTransactionScope())
-            using (var scope2 = new RebusTransactionScope())
-            {
-                var message1 = await transport1.Receive(scope1.TransactionContext, CancellationToken.None);
-                var message2 = await transport2.Receive(scope2.TransactionContext, CancellationToken.None);
+            using var scope1 = new RebusTransactionScope();
+            using var scope2 = new RebusTransactionScope();
+            var message1 = await transport1.Receive(scope1.TransactionContext, CancellationToken.None);
+            var message2 = await transport2.Receive(scope2.TransactionContext, CancellationToken.None);
 
-                Assert.That(message1, Is.Not.Null);
-                Assert.That(Encoding.UTF8.GetString(message1.Body), Is.EqualTo(sentText));
+            Assert.That(message1, Is.Not.Null);
+            Assert.That(Encoding.UTF8.GetString(message1.Body), Is.EqualTo(sentText));
 
-                Assert.That(message2, Is.Null, 
-                    "Expected the second message to be null, because we should NOT be able to accidentally peek at the same message as another ongoing transaction");
+            Assert.That(message2, Is.Null,
+                "Expected the second message to be null, because we should NOT be able to accidentally peek at the same message as another ongoing transaction");
 
-                await scope2.CompleteAsync();
-                await scope1.CompleteAsync();
-            }
+            await scope2.CompleteAsync();
+            await scope1.CompleteAsync();
         }
 
         SqlServerTransport GetTransport(string connectionString, IsolationLevel isolationLevel)

--- a/Rebus.SqlServer.Tests/Bugs/TestErrorMessageWhenUsingSqlTransportAndRegisteringTimeoutManager.cs
+++ b/Rebus.SqlServer.Tests/Bugs/TestErrorMessageWhenUsingSqlTransportAndRegisteringTimeoutManager.cs
@@ -14,7 +14,7 @@ namespace Rebus.SqlServer.Tests.Bugs
             try
             {
                 Configure.With(new BuiltinHandlerActivator())
-                    .Transport(t => t.UseSqlServer(SqlTestHelper.ConnectionString, "whatever"))
+                    .Transport(t => t.UseSqlServer(new SqlServerTransportOptions(SqlTestHelper.ConnectionString), "whatever"))
                     .Timeouts(t => t.StoreInSqlServer(SqlTestHelper.ConnectionString, "timeouts"))
                     .Start();
             }

--- a/Rebus.SqlServer.Tests/Bugs/TestNativeDeferToSomeoneElse.cs
+++ b/Rebus.SqlServer.Tests/Bugs/TestNativeDeferToSomeoneElse.cs
@@ -31,11 +31,11 @@ namespace Rebus.SqlServer.Tests.Bugs
             Using(receiver);
 
             Configure.With(receiver)
-                .Transport(t => t.UseSqlServer(ConnectionString, "receiver"))
+                .Transport(t => t.UseSqlServer(new SqlServerTransportOptions(ConnectionString), "receiver"))
                 .Start();
 
             var senderBus = Configure.With(new BuiltinHandlerActivator())
-                .Transport(x => x.UseSqlServerAsOneWayClient(ConnectionString))
+                .Transport(x => x.UseSqlServerAsOneWayClient(new SqlServerTransportOptions(ConnectionString)))
                 .Routing(r => r.TypeBased().Map<string>("receiver"))
                 .Options(o =>
                 {

--- a/Rebus.SqlServer.Tests/Bugs/TestNativeDeferToSomeoneElse.cs
+++ b/Rebus.SqlServer.Tests/Bugs/TestNativeDeferToSomeoneElse.cs
@@ -80,12 +80,9 @@ namespace Rebus.SqlServer.Tests.Bugs
             public async Task Process(OutgoingStepContext context, Func<Task> next)
             {
                 var message = context.Load<Message>();
-
-                string temp;
-
-                if (message.Headers.TryGetValue(Headers.DeferredUntil, out temp))
+                if (message.Headers.TryGetValue(Headers.DeferredUntil, out _))
                 {
-                    if (!message.Headers.TryGetValue(Headers.DeferredRecipient, out temp)
+                    if (!message.Headers.TryGetValue(Headers.DeferredRecipient, out var temp)
                         || temp == null)
                     {
                         try

--- a/Rebus.SqlServer.Tests/DataBus/TestSqlServerDataBusLazyRead.cs
+++ b/Rebus.SqlServer.Tests/DataBus/TestSqlServerDataBusLazyRead.cs
@@ -41,23 +41,21 @@ namespace Rebus.SqlServer.Tests.DataBus
             Console.WriteLine("Reading data...");
 
             var stopwatch = Stopwatch.StartNew();
-            using (var source = await _storage.Read(dataId))
-            using (var destination = new MemoryStream())
-            {
-                var elapsedWhenStreamIsOpen = stopwatch.Elapsed;
+            using var source = await _storage.Read(dataId);
+            using var destination = new MemoryStream();
+            var elapsedWhenStreamIsOpen = stopwatch.Elapsed;
 
-                Console.WriteLine($"Opening stream took {elapsedWhenStreamIsOpen.TotalSeconds:0.00} s");
+            Console.WriteLine($"Opening stream took {elapsedWhenStreamIsOpen.TotalSeconds:0.00} s");
 
-                await source.CopyToAsync(destination);
+            await source.CopyToAsync(destination);
 
-                var elapsedWhenStreamHasBeenRead = stopwatch.Elapsed;
+            var elapsedWhenStreamHasBeenRead = stopwatch.Elapsed;
 
-                Console.WriteLine($"Entire operation took {elapsedWhenStreamHasBeenRead.TotalSeconds:0.00} s");
+            Console.WriteLine($"Entire operation took {elapsedWhenStreamHasBeenRead.TotalSeconds:0.00} s");
 
-                var fraction = elapsedWhenStreamHasBeenRead.TotalSeconds/10;
-                Assert.That(elapsedWhenStreamIsOpen.TotalSeconds, Is.LessThan(fraction), 
-                    "Expected time to open stream to be less than 1/10 of the time it takes to read the entire stream");
-            }
+            var fraction = elapsedWhenStreamHasBeenRead.TotalSeconds / 10;
+            Assert.That(elapsedWhenStreamIsOpen.TotalSeconds, Is.LessThan(fraction),
+                "Expected time to open stream to be less than 1/10 of the time it takes to read the entire stream");
         }
 
         static byte[] GenerateData(int byteCount)

--- a/Rebus.SqlServer.Tests/DataBus/TestSqlServerDataBusStorage.cs
+++ b/Rebus.SqlServer.Tests/DataBus/TestSqlServerDataBusStorage.cs
@@ -68,11 +68,9 @@ You know, that or, uh, His Dudeness, or uh, Duder, or El Duderino if you're not 
                             Console.Write(".");
                             try
                             {
-                                using (var source = _storage.Read(dataId).Result)
-                                using (var destination = new MemoryStream())
-                                {
-                                    source.CopyTo(destination);
-                                }
+                                using var source = _storage.Read(dataId).Result;
+                                using var destination = new MemoryStream();
+                                source.CopyTo(destination);
                             }
                             catch (Exception exception)
                             {

--- a/Rebus.SqlServer.Tests/Extensions/ConnectionExtensions.cs
+++ b/Rebus.SqlServer.Tests/Extensions/ConnectionExtensions.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
-using Microsoft.Data.SqlClient;
 using System.Linq;
+using Microsoft.Data.SqlClient;
 
 namespace Rebus.SqlServer.Tests.Extensions
 {

--- a/Rebus.SqlServer.Tests/Extensions/ConnectionExtensions.cs
+++ b/Rebus.SqlServer.Tests/Extensions/ConnectionExtensions.cs
@@ -9,29 +9,25 @@ namespace Rebus.SqlServer.Tests.Extensions
     {
         public static IEnumerable<T> Query<T>(this SqlConnection connection, string query)
         {
-            using (var command = connection.CreateCommand())
+            using var command = connection.CreateCommand();
+            command.CommandText = query;
+
+            var properties = typeof(T).GetProperties().Select(p => p.Name).ToArray();
+
+            using var reader = command.ExecuteReader();
+            while (reader.Read())
             {
-                command.CommandText = query;
+                var instance = Activator.CreateInstance(typeof(T));
 
-                var properties = typeof(T).GetProperties().Select(p => p.Name).ToArray();
-
-                using (var reader = command.ExecuteReader())
+                foreach (var name in properties)
                 {
-                    while (reader.Read())
-                    {
-                        var instance = Activator.CreateInstance(typeof(T));
+                    var ordinal = reader.GetOrdinal(name);
+                    var value = reader.GetValue(ordinal);
 
-                        foreach (var name in properties)
-                        {
-                            var ordinal = reader.GetOrdinal(name);
-                            var value = reader.GetValue(ordinal);
-
-                            instance.GetType().GetProperty(name).SetValue(instance, value);
-                        }
-
-                        yield return (T)instance;
-                    }
+                    instance.GetType().GetProperty(name).SetValue(instance, value);
                 }
+
+                yield return (T)instance;
             }
         }
     }

--- a/Rebus.SqlServer.Tests/FakeRebusTime.cs
+++ b/Rebus.SqlServer.Tests/FakeRebusTime.cs
@@ -9,7 +9,6 @@ namespace Rebus.SqlServer.Tests
 
         public DateTimeOffset Now => _nowFactory();
 
-
         public void SetNow(DateTimeOffset fakeTime) => _nowFactory = () => fakeTime;
     }
 }

--- a/Rebus.SqlServer.Tests/Integration/NativeDeferTest.cs
+++ b/Rebus.SqlServer.Tests/Integration/NativeDeferTest.cs
@@ -30,7 +30,7 @@ namespace Rebus.SqlServer.Tests.Integration
             Using(_activator);
 
             _bus = Configure.With(_activator)
-                .Transport(t => t.UseSqlServer(SqlTestHelper.ConnectionString, QueueName))
+                .Transport(t => t.UseSqlServer(new SqlServerTransportOptions(SqlTestHelper.ConnectionString), QueueName))
                 .Routing(r => r.TypeBased().Map<TimedMessage>(QueueName))
                 .Options(o =>
                 {

--- a/Rebus.SqlServer.Tests/Integration/TestNumberOfSqlConnections.cs
+++ b/Rebus.SqlServer.Tests/Integration/TestNumberOfSqlConnections.cs
@@ -1,9 +1,9 @@
 ﻿using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using Microsoft.Data.SqlClient;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Data.SqlClient;
 using NUnit.Framework;
 using Rebus.Activation;
 using Rebus.Config;

--- a/Rebus.SqlServer.Tests/Integration/TestNumberOfSqlConnections.cs
+++ b/Rebus.SqlServer.Tests/Integration/TestNumberOfSqlConnections.cs
@@ -99,9 +99,7 @@ namespace Rebus.SqlServer.Tests.Integration
                 public void Dispose()
                 {
                     _innerConnection.Dispose();
-
-                    object o;
-                    _activeConnections.TryRemove(_id, out o);
+                    _activeConnections.TryRemove(_id, out _);
                 }
             }
         }

--- a/Rebus.SqlServer.Tests/Integration/TestSqlAllTheWay.cs
+++ b/Rebus.SqlServer.Tests/Integration/TestSqlAllTheWay.cs
@@ -29,7 +29,7 @@ namespace Rebus.SqlServer.Tests.Integration
             Using(_activator);
 
             _bus = Configure.With(_activator)
-                .Transport(x => x.UseSqlServer(ConnectionString, "test.input"))
+                .Transport(x => x.UseSqlServer(new SqlServerTransportOptions(ConnectionString), "test.input"))
                 .Sagas(x => x.StoreInSqlServer(ConnectionString, "Sagas", "SagaIndex"))
                 .Options(x =>
                 {

--- a/Rebus.SqlServer.Tests/Sagas/SqlServerSnapshotStorageFactory.cs
+++ b/Rebus.SqlServer.Tests/Sagas/SqlServerSnapshotStorageFactory.cs
@@ -45,15 +45,13 @@ namespace Rebus.SqlServer.Tests.Sagas
                 {
                     command.CommandText = $@"SELECT * FROM [{tableName}]";
 
-                    using (var reader = command.ExecuteReader())
+                    using var reader = command.ExecuteReader();
+                    while (await reader.ReadAsync())
                     {
-                        while (await reader.ReadAsync())
-                        {
-                            var sagaData = (ISagaData)new ObjectSerializer().DeserializeFromString((string)reader["data"]);
-                            var metadata = new HeaderSerializer().DeserializeFromString((string)reader["metadata"]);
+                        var sagaData = (ISagaData)new ObjectSerializer().DeserializeFromString((string)reader["data"]);
+                        var metadata = new HeaderSerializer().DeserializeFromString((string)reader["metadata"]);
 
-                            storedCopies.Add(new SagaDataSnapshot{SagaData = sagaData, Metadata = metadata});
-                        }
+                        storedCopies.Add(new SagaDataSnapshot { SagaData = sagaData, Metadata = metadata });
                     }
                 }
 

--- a/Rebus.SqlServer.Tests/Sagas/TestSqlServerSagaStorage.cs
+++ b/Rebus.SqlServer.Tests/Sagas/TestSqlServerSagaStorage.cs
@@ -104,21 +104,19 @@ CREATE TABLE [dbo].[{_indexTableName}](
 
             Console.WriteLine($"Creating tables {_dataTableName} and {_indexTableName}");
 
-            using (var connection = await _connectionProvider.GetConnection())
+            using var connection = await _connectionProvider.GetConnection();
+            using (var command = connection.CreateCommand())
             {
-                using (var command = connection.CreateCommand())
-                {
-                    command.CommandText = createTableOldSchema;
-                    command.ExecuteNonQuery();
-                }
-                using (var command = connection.CreateCommand())
-                {
-                    command.CommandText = createTableOldSchema2;
-                    command.ExecuteNonQuery();
-                }
-
-                await connection.Complete();
+                command.CommandText = createTableOldSchema;
+                command.ExecuteNonQuery();
             }
+            using (var command = connection.CreateCommand())
+            {
+                command.CommandText = createTableOldSchema2;
+                command.ExecuteNonQuery();
+            }
+
+            await connection.Complete();
         }
     }
 }

--- a/Rebus.SqlServer.Tests/SqlTestHelper.cs
+++ b/Rebus.SqlServer.Tests/SqlTestHelper.cs
@@ -1,9 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
-using Microsoft.Data.SqlClient;
 using System.Linq;
-using Rebus.SqlServer.Tests.Extensions;
+using Microsoft.Data.SqlClient;
 using Rebus.Exceptions;
+using Rebus.SqlServer.Tests.Extensions;
 using Rebus.Tests.Contracts;
 
 namespace Rebus.SqlServer.Tests

--- a/Rebus.SqlServer.Tests/SqlTestHelper.cs
+++ b/Rebus.SqlServer.Tests/SqlTestHelper.cs
@@ -42,28 +42,24 @@ namespace Rebus.SqlServer.Tests
 
         public static void Execute(string sql)
         {
-            using (var connection = new SqlConnection(ConnectionString))
+            using var connection = new SqlConnection(ConnectionString);
+            connection.Open();
+
+            Console.Write($"SQL => {sql}        -- ");
+
+            using var command = connection.CreateCommand();
+            command.CommandText = sql;
+
+            try
             {
-                connection.Open();
+                command.ExecuteNonQuery();
 
-                Console.Write($"SQL => {sql}        -- ");
-
-                using (var command = connection.CreateCommand())
-                {
-                    command.CommandText = sql;
-
-                    try
-                    {
-                        command.ExecuteNonQuery();
-
-                        Console.WriteLine("OK");
-                    }
-                    catch
-                    {
-                        Console.WriteLine("Fail");
-                        throw;
-                    }
-                }
+                Console.WriteLine("OK");
+            }
+            catch
+            {
+                Console.WriteLine("Fail");
+                throw;
             }
         }
 
@@ -96,27 +92,25 @@ namespace Rebus.SqlServer.Tests
         {
             try
             {
-                using (var connection = new SqlConnection(ConnectionString))
+                using var connection = new SqlConnection(ConnectionString);
+                connection.Open();
+
+                var shouldExecute = executeCriteria(connection);
+                if (!shouldExecute) return;
+
+                try
                 {
-                    connection.Open();
-
-                    var shouldExecute = executeCriteria(connection);
-                    if (!shouldExecute) return;
-
-                    try
+                    using (var command = connection.CreateCommand())
                     {
-                        using (var command = connection.CreateCommand())
-                        {
-                            command.CommandText = sqlCommand;
-                            command.ExecuteNonQuery();
-                        }
+                        command.CommandText = sqlCommand;
+                        command.ExecuteNonQuery();
+                    }
 
-                        Console.WriteLine($"SQL OK: {sqlCommand}");
-                    }
-                    catch (SqlException exception) when (exception.Number == SqlServerMagic.ObjectDoesNotExistOrNoPermission)
-                    {
-                        // it's alright
-                    }
+                    Console.WriteLine($"SQL OK: {sqlCommand}");
+                }
+                catch (SqlException exception) when (exception.Number == SqlServerMagic.ObjectDoesNotExistOrNoPermission)
+                {
+                    // it's alright
                 }
             }
             catch (Exception exception)
@@ -153,14 +147,12 @@ Here are all the currently active connections:
 
         public static IEnumerable<T> Query<T>(string query)
         {
-            using (var connection = new SqlConnection(ConnectionString))
-            {
-                connection.Open();
+            using var connection = new SqlConnection(ConnectionString);
+            connection.Open();
 
-                foreach (var result in connection.Query<T>(query))
-                {
-                    yield return result;
-                }
+            foreach (var result in connection.Query<T>(query))
+            {
+                yield return result;
             }
         }
 
@@ -196,19 +188,15 @@ Here are all the currently active connections:
             using (var connection = new SqlConnection(ConnectionString))
             {
                 connection.Open();
-                using (var command = connection.CreateCommand())
-                {
-                    command.CommandText = @"
+                using var command = connection.CreateCommand();
+                command.CommandText = @"
 select s.name as 'schema', t.name as 'table' from sys.tables t
 	join sys.schemas s on s.schema_id = t.schema_id
 ";
-                    using (var reader = command.ExecuteReader())
-                    {
-                        while (reader.Read())
-                        {
-                            tableNames.Add(new TableName((string)reader["schema"], (string)reader["table"]));
-                        }
-                    }
+                using var reader = command.ExecuteReader();
+                while (reader.Read())
+                {
+                    tableNames.Add(new TableName((string)reader["schema"], (string)reader["table"]));
                 }
             }
 
@@ -217,33 +205,27 @@ select s.name as 'schema', t.name as 'table' from sys.tables t
 
         public static IEnumerable<IDictionary<string, string>> ExecSpWho()
         {
-            using (var connection = new SqlConnection(ConnectionString))
+            using var connection = new SqlConnection(ConnectionString);
+            connection.Open();
+
+            using var command = connection.CreateCommand();
+            command.CommandText = "sp_who;";
+
+            using var reader = command.ExecuteReader();
+            var rows = new List<Dictionary<string, string>>();
+
+            while (reader.Read())
             {
-                connection.Open();
-
-                using (var command = connection.CreateCommand())
-                {
-                    command.CommandText = "sp_who;";
-
-                    using (var reader = command.ExecuteReader())
+                rows.Add(Enumerable.Range(0, reader.FieldCount)
+                    .Select(field => new
                     {
-                        var rows = new List<Dictionary<string, string>>();
-
-                        while (reader.Read())
-                        {
-                            rows.Add(Enumerable.Range(0, reader.FieldCount)
-                                .Select(field => new
-                                {
-                                    ColumnName = reader.GetName(field),
-                                    Value = (reader.GetValue(field) ?? "").ToString().Trim()
-                                })
-                                .ToDictionary(a => a.ColumnName, a => a.Value));
-                        }
-
-                        return rows;
-                    }
-                }
+                        ColumnName = reader.GetName(field),
+                        Value = (reader.GetValue(field) ?? "").ToString().Trim()
+                    })
+                    .ToDictionary(a => a.ColumnName, a => a.Value));
             }
+
+            return rows;
         }
 
         static void InitializeDatabase(string databaseName)
@@ -256,20 +238,18 @@ select s.name as 'schema', t.name as 'table' from sys.tables t
                 {
                     connection.Open();
 
-                    using (var command = connection.CreateCommand())
+                    using var command = connection.CreateCommand();
+                    command.CommandText = $"CREATE DATABASE [{databaseName}]";
+
+                    try
                     {
-                        command.CommandText = $"CREATE DATABASE [{databaseName}]";
-
-                        try
-                        {
-                            command.ExecuteNonQuery();
-                        }
-                        catch (SqlException exception) when (exception.Number == 1801)
-                        {
-                        }
-
-                        Console.WriteLine("Created database {0}", databaseName);
+                        command.ExecuteNonQuery();
                     }
+                    catch (SqlException exception) when (exception.Number == 1801)
+                    {
+                    }
+
+                    Console.WriteLine("Created database {0}", databaseName);
                 }
 
                 _databaseHasBeenInitialized = true;

--- a/Rebus.SqlServer.Tests/Transport/Contract/Factories/SqlLeaseTransportFactory.cs
+++ b/Rebus.SqlServer.Tests/Transport/Contract/Factories/SqlLeaseTransportFactory.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using Rebus.Config;
-using Rebus.Extensions;
 using Rebus.Logging;
 using Rebus.SqlServer.Transport;
 using Rebus.Tests.Contracts;

--- a/Rebus.SqlServer.Tests/Transport/Contract/Factories/SqlServerBusFactory.cs
+++ b/Rebus.SqlServer.Tests/Transport/Contract/Factories/SqlServerBusFactory.cs
@@ -29,7 +29,7 @@ namespace Rebus.SqlServer.Tests.Transport.Contract.Factories
             SqlTestHelper.DropTable(tableName);
 
             var bus = Configure.With(builtinHandlerActivator)
-                .Transport(t => t.UseSqlServer(SqlTestHelper.ConnectionString, inputQueueAddress))
+                .Transport(t => t.UseSqlServer(new SqlServerTransportOptions(SqlTestHelper.ConnectionString), inputQueueAddress))
                 .Options(o =>
                 {
                     o.SetNumberOfWorkers(10);

--- a/Rebus.SqlServer.Tests/Transport/Contract/Factories/SqlServerLeaseBusFactory.cs
+++ b/Rebus.SqlServer.Tests/Transport/Contract/Factories/SqlServerLeaseBusFactory.cs
@@ -29,7 +29,7 @@ namespace Rebus.SqlServer.Tests.Transport.Contract.Factories
             SqlTestHelper.DropTable(tableName);
 
             var bus = Configure.With(builtinHandlerActivator)
-                .Transport(t => t.UseSqlServerInLeaseMode(SqlTestHelper.ConnectionString, inputQueueAddress))
+                .Transport(t => t.UseSqlServerInLeaseMode(new SqlServerLeaseTransportOptions(SqlTestHelper.ConnectionString), inputQueueAddress))
                 .Options(o =>
                 {
                     o.SetNumberOfWorkers(10);

--- a/Rebus.SqlServer.Tests/Transport/Contract/Factories/SqlTransportFactory.cs
+++ b/Rebus.SqlServer.Tests/Transport/Contract/Factories/SqlTransportFactory.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using Rebus.Config;
-using Rebus.Extensions;
 using Rebus.Logging;
 using Rebus.SqlServer.Transport;
 using Rebus.Tests.Contracts;

--- a/Rebus.SqlServer.Tests/Transport/TestDbConnectionProvider.cs
+++ b/Rebus.SqlServer.Tests/Transport/TestDbConnectionProvider.cs
@@ -15,41 +15,31 @@ namespace Rebus.SqlServer.Tests.Transport
         {
             var provizzle = new DbConnectionProvider(SqlTestHelper.ConnectionString, new ConsoleLoggerFactory(true));
 
-            using (var dbConnection = await provizzle.GetConnection())
-            {
-                using (var cmd = dbConnection.CreateCommand())
-                {
-                    cmd.CommandText = "insert into bimse (text) values ('hej med dig')";
+            using var dbConnection = await provizzle.GetConnection();
+            using var cmd = dbConnection.CreateCommand();
+            cmd.CommandText = "insert into bimse (text) values ('hej med dig')";
                     
-                    await cmd.ExecuteNonQueryAsync();
-                }
+            await cmd.ExecuteNonQueryAsync();
 
-                //await dbConnection.Complete();
-            }
+            //await dbConnection.Complete();
         }
         [Test, Ignore("assumes existence of a bimse table")]
         public async Task CanDoWorkInAmbientTransaction()
         {
-            using (var tx = new TransactionScope(TransactionScopeOption.Required, new TransactionOptions
+            using var tx = new TransactionScope(TransactionScopeOption.Required, new TransactionOptions
             {
                 IsolationLevel = IsolationLevel.ReadCommitted,
                 Timeout = TimeSpan.FromSeconds(60)
-            }))
-            {
-                var provizzle = new DbConnectionProvider(SqlTestHelper.ConnectionString, new ConsoleLoggerFactory(true), 
-                    enlistInAmbientTransaction: true);
+            });
+            var provizzle = new DbConnectionProvider(SqlTestHelper.ConnectionString, new ConsoleLoggerFactory(true),
+                enlistInAmbientTransaction: true);
 
-                using (var dbConnection = await provizzle.GetConnection())
-                {
-                    using (var cmd = dbConnection.CreateCommand())
-                    {
-                        cmd.CommandText = "insert into bimse (text) values ('Nogen fjellaper liger 2PC')";
+            using var dbConnection = await provizzle.GetConnection();
+            using var cmd = dbConnection.CreateCommand();
+            cmd.CommandText = "insert into bimse (text) values ('Nogen fjellaper liger 2PC')";
                     
-                        await cmd.ExecuteNonQueryAsync();
-                    }
-                }
-                // tx.Complete();
-            }
+            await cmd.ExecuteNonQueryAsync();
+            // tx.Complete();
         }
     }
 }

--- a/Rebus.SqlServer.Tests/Transport/TestMessagePriority.cs
+++ b/Rebus.SqlServer.Tests/Transport/TestMessagePriority.cs
@@ -46,11 +46,11 @@ namespace Rebus.SqlServer.Tests.Transport
                 {
                     if (type == "normal")
                     {
-                        t.UseSqlServer(SqlTestHelper.ConnectionString, "server");
+                        t.UseSqlServer(new SqlServerTransportOptions(SqlTestHelper.ConnectionString), "server");
                     }
                     else
                     {
-                        t.UseSqlServerInLeaseMode(SqlTestHelper.ConnectionString, "server");
+                        t.UseSqlServerInLeaseMode(new SqlServerLeaseTransportOptions(SqlTestHelper.ConnectionString), "server");
                     }
                 })
                 .Options(o =>
@@ -65,11 +65,11 @@ namespace Rebus.SqlServer.Tests.Transport
                 {
                     if (type == "normal")
                     {
-                        t.UseSqlServerAsOneWayClient(SqlTestHelper.ConnectionString);
+                        t.UseSqlServerAsOneWayClient(new SqlServerTransportOptions(SqlTestHelper.ConnectionString));
                     }
                     else
                     {
-                        t.UseSqlServerInLeaseModeAsOneWayClient(SqlTestHelper.ConnectionString);
+                        t.UseSqlServerInLeaseModeAsOneWayClient(new SqlServerLeaseTransportOptions(SqlTestHelper.ConnectionString));
                     }
                 })
                 .Routing(t => t.TypeBased().Map<string>("server"))

--- a/Rebus.SqlServer.Tests/Transport/TestSqlServerTransportCleanup.cs
+++ b/Rebus.SqlServer.Tests/Transport/TestSqlServerTransportCleanup.cs
@@ -31,7 +31,7 @@ namespace Rebus.SqlServer.Tests.Transport
 
             Configure.With(_activator)
                 .Logging(l => l.Use(_loggerFactory))
-                .Transport(t => t.UseSqlServer(SqlTestHelper.ConnectionString, queueName))
+                .Transport(t => t.UseSqlServer(new SqlServerTransportOptions(SqlTestHelper.ConnectionString), queueName))
                 .Start();
         }
 

--- a/Rebus.SqlServer.Tests/Transport/TestSqlServerTransportMessageOrdering.cs
+++ b/Rebus.SqlServer.Tests/Transport/TestSqlServerTransportMessageOrdering.cs
@@ -45,18 +45,16 @@ namespace Rebus.SqlServer.Tests.Transport
 
         static async Task<string> ReceiveMessageBody(ITransport transport)
         {
-            using (var scope = new RebusTransactionScope())
-            {
-                var transportMessage = await transport.Receive(scope.TransactionContext, CancellationToken.None);
+            using var scope = new RebusTransactionScope();
+            var transportMessage = await transport.Receive(scope.TransactionContext, CancellationToken.None);
 
-                if (transportMessage == null) return null;
+            if (transportMessage == null) return null;
 
-                var body = Encoding.UTF8.GetString(transportMessage.Body);
+            var body = Encoding.UTF8.GetString(transportMessage.Body);
 
-                await scope.CompleteAsync();
+            await scope.CompleteAsync();
 
-                return body;
-            }
+            return body;
         }
 
         public enum TransportType
@@ -83,11 +81,9 @@ namespace Rebus.SqlServer.Tests.Transport
 
         static async Task PutInQueue(ITransport transport, TransportMessage transportMessage)
         {
-            using (var scope = new RebusTransactionScope())
-            {
-                await transport.Send(QueueName, transportMessage, scope.TransactionContext);
-                await scope.CompleteAsync();
-            }
+            using var scope = new RebusTransactionScope();
+            await transport.Send(QueueName, transportMessage, scope.TransactionContext);
+            await scope.CompleteAsync();
         }
 
         static SqlServerTransport GetTransport(TransportType transportType)

--- a/Rebus.SqlServer/Config/SqlServerSagaConfigurationExtensions.cs
+++ b/Rebus.SqlServer/Config/SqlServerSagaConfigurationExtensions.cs
@@ -18,8 +18,7 @@ namespace Rebus.Config
         /// </summary>
         public static void StoreInSqlServer(this StandardConfigurer<ISagaStorage> configurer,
             string connectionString, string dataTableName, string indexTableName,
-            bool automaticallyCreateTables = true, bool enlistInAmbientTransaction = false
-    )
+            bool automaticallyCreateTables = true, bool enlistInAmbientTransaction = false)
         {
             if (configurer == null) throw new ArgumentNullException(nameof(configurer));
             if (connectionString == null) throw new ArgumentNullException(nameof(connectionString));

--- a/Rebus.SqlServer/Config/SqlServerTransportConfigurationExtensions.cs
+++ b/Rebus.SqlServer/Config/SqlServerTransportConfigurationExtensions.cs
@@ -266,7 +266,6 @@ namespace Rebus.Config
                 .SetEnsureTablesAreCreated(ensureTablesAreCreated);
         }
 
-
         delegate SqlServerTransport TransportFactoryDelegate(IResolutionContext context, IDbConnectionProvider connectionProvider, string inputQueueName);
 
         static TTransportOptions Configure<TTransportOptions>(StandardConfigurer<ITransport> configurer, TransportFactoryDelegate transportFactory, TTransportOptions transportOptions) where TTransportOptions : SqlServerTransportOptions

--- a/Rebus.SqlServer/SqlServer/AsyncHelpers.cs
+++ b/Rebus.SqlServer/SqlServer/AsyncHelpers.cs
@@ -43,8 +43,7 @@ namespace Rebus.SqlServer
 
             public CustomSynchronizationContext(Func<Task> task)
             {
-                if (task == null) throw new ArgumentNullException(nameof(task), "Please remember to pass a Task to be executed");
-                _task = task;
+                _task = task ?? throw new ArgumentNullException(nameof(task), "Please remember to pass a Task to be executed");
             }
 
             public override void Post(SendOrPostCallback function, object state)
@@ -77,9 +76,7 @@ namespace Rebus.SqlServer
 
                 while (!_done)
                 {
-                    Tuple<SendOrPostCallback, object> task;
-
-                    if (_items.TryDequeue(out task))
+                    if (_items.TryDequeue(out var task))
                     {
                         task.Item1(task.Item2);
 

--- a/Rebus.SqlServer/SqlServer/DataBus/SqlServerDataBusStorage.cs
+++ b/Rebus.SqlServer/SqlServer/DataBus/SqlServerDataBusStorage.cs
@@ -62,7 +62,6 @@ namespace Rebus.SqlServer.DataBus
                 // if it failed because of a collision between another thread doing the same thing, just try again once:
                 AsyncHelpers.RunSync(EnsureTableIsCreatedAsync);
             }
-
         }
 
         async Task EnsureTableIsCreatedAsync()

--- a/Rebus.SqlServer/SqlServer/DataBus/StreamWrapper.cs
+++ b/Rebus.SqlServer/SqlServer/DataBus/StreamWrapper.cs
@@ -65,5 +65,4 @@ namespace Rebus.SqlServer.DataBus
             base.Dispose(disposing);
         }
     }
-
 }

--- a/Rebus.SqlServer/SqlServer/DataBus/StreamWrapper.cs
+++ b/Rebus.SqlServer/SqlServer/DataBus/StreamWrapper.cs
@@ -15,9 +15,8 @@ namespace Rebus.SqlServer.DataBus
 
         public StreamWrapper(Stream innerStream, IEnumerable<IDisposable> disposables)
         {
-            if (innerStream == null) throw new ArgumentNullException(nameof(innerStream));
+            _innerStream = innerStream ?? throw new ArgumentNullException(nameof(innerStream));
             if (disposables == null) throw new ArgumentNullException(nameof(disposables));
-            _innerStream = innerStream;
             _disposables = disposables.ToArray();
         }
 

--- a/Rebus.SqlServer/SqlServer/DbConnectionProvider.cs
+++ b/Rebus.SqlServer/SqlServer/DbConnectionProvider.cs
@@ -1,7 +1,7 @@
 ﻿using System;
-using Microsoft.Data.SqlClient;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.Data.SqlClient;
 using Rebus.Logging;
 using IsolationLevel = System.Data.IsolationLevel;
 

--- a/Rebus.SqlServer/SqlServer/DbConnectionWrapper.cs
+++ b/Rebus.SqlServer/SqlServer/DbConnectionWrapper.cs
@@ -1,7 +1,7 @@
 ﻿using System.Collections.Generic;
-using Microsoft.Data.SqlClient;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.Data.SqlClient;
 using Rebus.Exceptions;
 
 #pragma warning disable 1998

--- a/Rebus.SqlServer/SqlServer/IDbConnection.cs
+++ b/Rebus.SqlServer/SqlServer/IDbConnection.cs
@@ -1,8 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Data;
-using Microsoft.Data.SqlClient;
 using System.Threading.Tasks;
+using Microsoft.Data.SqlClient;
 
 namespace Rebus.SqlServer
 {

--- a/Rebus.SqlServer/SqlServer/IDbConnectionProvider.cs
+++ b/Rebus.SqlServer/SqlServer/IDbConnectionProvider.cs
@@ -1,5 +1,5 @@
-using Microsoft.Data.SqlClient;
 using System.Threading.Tasks;
+using Microsoft.Data.SqlClient;
 
 namespace Rebus.SqlServer
 {

--- a/Rebus.SqlServer/SqlServer/Ponder.cs
+++ b/Rebus.SqlServer/SqlServer/Ponder.cs
@@ -1,15 +1,7 @@
-﻿using System;
-using System.Linq.Expressions;
-
-namespace Rebus.SqlServer
+﻿namespace Rebus.SqlServer
 {
     class Reflect
     {
-        public static string Path<T>(Expression<Func<T, object>> expression)
-        {
-            return GetPropertyName(expression);
-        }
-
         public static object Value(object obj, string path)
         {
             var dots = path.Split('.');
@@ -23,48 +15,6 @@ namespace Rebus.SqlServer
             }
 
             return obj;
-        }
-
-        static string GetPropertyName(Expression expression)
-        {
-            if (expression == null) return "";
-
-            if (expression is LambdaExpression lExpression)
-            {
-                expression = lExpression.Body;
-            }
-
-            if (expression is UnaryExpression uExpression)
-            {
-                expression = uExpression.Operand;
-            }
-
-            if (expression is MemberExpression)
-            {
-                dynamic memberExpression = expression;
-
-                var lambdaExpression = (Expression)memberExpression.Expression;
-
-                string prefix;
-                if (lambdaExpression != null)
-                {
-                    prefix = GetPropertyName(lambdaExpression);
-                    if (!string.IsNullOrEmpty(prefix))
-                    {
-                        prefix += ".";
-                    }
-                }
-                else
-                {
-                    prefix = "";
-                }
-
-                var propertyName = memberExpression.Member.Name;
-                
-                return prefix + propertyName;
-            }
-
-            return "";
         }
     }
 }

--- a/Rebus.SqlServer/SqlServer/Ponder.cs
+++ b/Rebus.SqlServer/SqlServer/Ponder.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Linq.Expressions;
 
 namespace Rebus.SqlServer
@@ -29,14 +29,14 @@ namespace Rebus.SqlServer
         {
             if (expression == null) return "";
 
-            if (expression is LambdaExpression)
+            if (expression is LambdaExpression lExpression)
             {
-                expression = ((LambdaExpression) expression).Body;
+                expression = lExpression.Body;
             }
 
-            if (expression is UnaryExpression)
+            if (expression is UnaryExpression uExpression)
             {
-                expression = ((UnaryExpression)expression).Operand;
+                expression = uExpression.Operand;
             }
 
             if (expression is MemberExpression)

--- a/Rebus.SqlServer/SqlServer/Sagas/SqlServerSagaSnapshotStorage.cs
+++ b/Rebus.SqlServer/SqlServer/Sagas/SqlServerSagaSnapshotStorage.cs
@@ -27,12 +27,11 @@ namespace Rebus.SqlServer.Sagas
         /// </summary>
         public SqlServerSagaSnapshotStorage(IDbConnectionProvider connectionProvider, string tableName, IRebusLoggerFactory rebusLoggerFactory)
         {
-            if (connectionProvider == null) throw new ArgumentNullException(nameof(connectionProvider));
+            _connectionProvider = connectionProvider ?? throw new ArgumentNullException(nameof(connectionProvider));
             if (tableName == null) throw new ArgumentNullException(nameof(tableName));
             if (rebusLoggerFactory == null) throw new ArgumentNullException(nameof(rebusLoggerFactory));
 
             _log = rebusLoggerFactory.GetLogger<SqlServerSagaSnapshotStorage>();
-            _connectionProvider = connectionProvider;
             _tableName = TableName.Parse(tableName);
         }
 

--- a/Rebus.SqlServer/SqlServer/Sagas/SqlServerSagaStorage.cs
+++ b/Rebus.SqlServer/SqlServer/Sagas/SqlServerSagaStorage.cs
@@ -39,15 +39,13 @@ namespace Rebus.SqlServer.Sagas
         /// </summary>
 		public SqlServerSagaStorage(IDbConnectionProvider connectionProvider, string dataTableName, string indexTableName, IRebusLoggerFactory rebusLoggerFactory, ISagaTypeNamingStrategy sagaTypeNamingStrategy)
         {
-            if (connectionProvider == null) throw new ArgumentNullException(nameof(connectionProvider));
+            _connectionProvider = connectionProvider ?? throw new ArgumentNullException(nameof(connectionProvider));
             if (dataTableName == null) throw new ArgumentNullException(nameof(dataTableName));
             if (indexTableName == null) throw new ArgumentNullException(nameof(indexTableName));
             if (rebusLoggerFactory == null) throw new ArgumentNullException(nameof(rebusLoggerFactory));
-            if (sagaTypeNamingStrategy == null) throw new ArgumentNullException(nameof(sagaTypeNamingStrategy));
+            _sagaTypeNamingStrategy = sagaTypeNamingStrategy ?? throw new ArgumentNullException(nameof(sagaTypeNamingStrategy));
 
             _log = rebusLoggerFactory.GetLogger<SqlServerSagaStorage>();
-            _connectionProvider = connectionProvider;
-            _sagaTypeNamingStrategy = sagaTypeNamingStrategy;
             _dataTableName = TableName.Parse(dataTableName);
             _indexTableName = TableName.Parse(indexTableName);
         }
@@ -571,7 +569,7 @@ saga type name.");
                 {
                     var value = Reflect.Value(sagaData, path);
 
-                    return new KeyValuePair<string, string>(path, value != null ? value.ToString() : null);
+                    return new KeyValuePair<string, string>(path, value?.ToString());
                 })
                 .Where(kvp => IndexNullProperties || kvp.Value != null)
                 .ToList();

--- a/Rebus.SqlServer/SqlServer/Sagas/SqlServerSagaStorage.cs
+++ b/Rebus.SqlServer/SqlServer/Sagas/SqlServerSagaStorage.cs
@@ -196,44 +196,6 @@ ALTER TABLE {_indexTableName.QualifiedName} CHECK CONSTRAINT [FK_{_dataTableName
             
         }
 
-        void VerifyDataTableSchema(string dataTableName, IDbConnection connection)
-        {
-            //  [id] [uniqueidentifier] NOT NULL,
-            //	[revision] [int] NOT NULL,
-            //	[data] [varbinary](max) NOT NULL,
-            var expectedDataTypes = new Dictionary<string, SqlDbType>(StringComparer.OrdinalIgnoreCase)
-            {
-                {"id", SqlDbType.UniqueIdentifier },
-                {"revision", SqlDbType.Int },
-                {"data", SqlDbType.VarBinary },
-            };
-
-            var tableName = TableName.Parse(dataTableName);
-            var columns = connection.GetColumns(tableName.Schema, tableName.Name);
-
-            foreach (var column in columns)
-            {
-                // we skip columns we don't know about - don't prevent people from adding their own columns
-                if (!expectedDataTypes.ContainsKey(column.Name)) continue;
-
-                var expectedDataType = expectedDataTypes[column.Name];
-
-                if (column.Type == expectedDataType) continue;
-
-                // special case: migrating from Rebus 0.99.59 to 0.99.60
-                if (column.Name == "data" && column.Type == SqlDbType.NVarChar && expectedDataType == SqlDbType.VarBinary)
-                {
-                    throw new RebusApplicationException(@"Sorry, but the [data] column data type was changed from NVarChar(MAX) to VarBinary(MAX) in Rebus 0.99.60.
-
-This was done because it turned out that SQL Server was EXTREMELY SLOW to load a saga's data when it was saved as NVarChar - you can expect a reduction in saga data loading time to about 1/10 of the previous time from Rebus version 0.99.60 and on.
-
-Unfortunately, Rebus cannot help migrating any existing pieces of saga data :( so we suggest you wait for a good time when the saga data table is empty, and then you simply wipe the tables and let Rebus (re-)create them.");
-                }
-
-                throw new RebusApplicationException($"The column [{column.Name}] has the type {column.Type} and not the expected {expectedDataType} data type!");
-            }
-        }
-
         /// <summary>
         /// Queries the saga index for an instance with the given <paramref name="sagaDataType"/> with a
         /// a property named <paramref name="propertyName"/> and the value <paramref name="propertyValue"/>
@@ -538,7 +500,6 @@ VALUES
                     throw;
                 }
             }
-
         }
 
         string GetSagaTypeName(Type sagaDataType)

--- a/Rebus.SqlServer/SqlServer/Sagas/SqlServerSagaStorage.cs
+++ b/Rebus.SqlServer/SqlServer/Sagas/SqlServerSagaStorage.cs
@@ -1,10 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Data;
-using Microsoft.Data.SqlClient;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using Microsoft.Data.SqlClient;
 using Rebus.Bus;
 using Rebus.Exceptions;
 using Rebus.Logging;

--- a/Rebus.SqlServer/SqlServer/SqlServerMagic.cs
+++ b/Rebus.SqlServer/SqlServer/SqlServerMagic.cs
@@ -84,14 +84,6 @@ namespace Rebus.SqlServer
             }
         }
 
-        /// <summary>
-        /// Gets the names of all databases on the current server
-        /// </summary>
-        public static List<string> GetDatabaseNames(this SqlConnection connection, SqlTransaction transaction = null)
-        {
-            return GetNamesFrom(connection, transaction, "sys.databases", new []{ "name" }).Select(x => (string)x.name).ToList();
-        }
-
         static List<dynamic> GetNamesFrom(SqlConnection connection, SqlTransaction transaction, string systemTableName, string[] columnNames)
         {
             var names = new List<dynamic>();

--- a/Rebus.SqlServer/SqlServer/SqlServerMagic.cs
+++ b/Rebus.SqlServer/SqlServer/SqlServerMagic.cs
@@ -1,9 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Data;
-using Microsoft.Data.SqlClient;
 using System.Dynamic;
 using System.Linq;
+using Microsoft.Data.SqlClient;
 
 namespace Rebus.SqlServer
 {

--- a/Rebus.SqlServer/SqlServer/Subscriptions/SqlServerSubscriptionStorage.cs
+++ b/Rebus.SqlServer/SqlServer/Subscriptions/SqlServerSubscriptionStorage.cs
@@ -29,14 +29,13 @@ namespace Rebus.SqlServer.Subscriptions
         /// </summary>
         public SqlServerSubscriptionStorage(IDbConnectionProvider connectionProvider, string tableName, bool isCentralized, IRebusLoggerFactory rebusLoggerFactory)
         {
-            if (connectionProvider == null) throw new ArgumentNullException(nameof(connectionProvider));
+            _connectionProvider = connectionProvider ?? throw new ArgumentNullException(nameof(connectionProvider));
             if (tableName == null) throw new ArgumentNullException(nameof(tableName));
             if (rebusLoggerFactory == null) throw new ArgumentNullException(nameof(rebusLoggerFactory));
 
             IsCentralized = isCentralized;
 
             _log = rebusLoggerFactory.GetLogger<SqlServerSubscriptionStorage>();
-            _connectionProvider = connectionProvider;
             _tableName = TableName.Parse(tableName);
         }
 

--- a/Rebus.SqlServer/SqlServer/Transport/SqlServerLeaseTransport.cs
+++ b/Rebus.SqlServer/SqlServer/Transport/SqlServerLeaseTransport.cs
@@ -403,6 +403,7 @@ WHERE	id = @id
                 await connection.Complete();
             }
         }
+
         /// <summary>
         /// Handles automatically renewing a lease for a given message
         /// </summary>
@@ -447,7 +448,6 @@ WHERE	id = @id
                 }
             }
         }
-
 
         class AddressedTransportMessage
         {

--- a/Rebus.SqlServer/SqlServer/Transport/SqlServerTransport.cs
+++ b/Rebus.SqlServer/SqlServer/Transport/SqlServerTransport.cs
@@ -1,11 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Data;
-using Microsoft.Data.SqlClient;
 using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Data.SqlClient;
 using Rebus.Bus;
 using Rebus.Config;
 using Rebus.Exceptions;

--- a/Rebus.SqlServer/SqlServer/Transport/SqlServerTransport.cs
+++ b/Rebus.SqlServer/SqlServer/Transport/SqlServerTransport.cs
@@ -47,6 +47,7 @@ namespace Rebus.SqlServer.Transport
         /// </summary>
         public static readonly TimeSpan DefaultExpiredMessagesCleanupInterval = TimeSpan.FromSeconds(20);
 
+        // TODO: This value should probably be used in creating of database
         /// <summary>
         /// Size, in the database, of the recipient column
         /// </summary>


### PR DESCRIPTION
Code cleanups performed during review of library
* used new C# constructs (4009f3d)
* removed unused code (6f926dc)
* used new UseSqlServer method (eb92764)
* sorted and removed using, made preferred grouping explicit (4f493c8)

use at will :)
---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.
