### PR TITLE
Changed unit tests to use the Create/Start API's to stop them failing

### DIFF
--- a/Rebus.SqlServer.Tests/Bugs/TestNativeDeferToSomeoneElse.cs
+++ b/Rebus.SqlServer.Tests/Bugs/TestNativeDeferToSomeoneElse.cs
@@ -30,9 +30,9 @@ namespace Rebus.SqlServer.Tests.Bugs
 
             Using(receiver);
 
-            Configure.With(receiver)
+            var receiverStarter = Configure.With(receiver)
                 .Transport(t => t.UseSqlServer(new SqlServerTransportOptions(ConnectionString), "receiver"))
-                .Start();
+                .Create();
 
             var senderBus = Configure.With(new BuiltinHandlerActivator())
                 .Transport(x => x.UseSqlServerAsOneWayClient(new SqlServerTransportOptions(ConnectionString)))
@@ -58,6 +58,7 @@ namespace Rebus.SqlServer.Tests.Bugs
             var gotTheString = new ManualResetEvent(false);
 
             receiver.Handle<string>(async message => gotTheString.Set());
+            receiverStarter.Start();
 
             var optionalHeaders = usePipelineStep
                 ? new Dictionary<string, string>()

--- a/Rebus.SqlServer.Tests/Transport/TestSqlServerTransportCleanup.cs
+++ b/Rebus.SqlServer.Tests/Transport/TestSqlServerTransportCleanup.cs
@@ -18,6 +18,7 @@ namespace Rebus.SqlServer.Tests.Transport
     {
         BuiltinHandlerActivator _activator;
         ListLoggerFactory _loggerFactory;
+        IBusStarter _starter;
 
         protected override void SetUp()
         {
@@ -29,10 +30,10 @@ namespace Rebus.SqlServer.Tests.Transport
 
             _loggerFactory = new ListLoggerFactory(outputToConsole: true);
 
-            Configure.With(_activator)
+            _starter = Configure.With(_activator)
                 .Logging(l => l.Use(_loggerFactory))
                 .Transport(t => t.UseSqlServer(new SqlServerTransportOptions(SqlTestHelper.ConnectionString), queueName))
-                .Start();
+                .Create();
         }
 
         [Test]
@@ -53,7 +54,8 @@ namespace Rebus.SqlServer.Tests.Transport
                 doneHandlingMessage.Set();
             });
 
-            _activator.Bus.SendLocal("hej med dig min ven!").Wait();
+            var bus = _starter.Start();
+            bus.SendLocal("hej med dig min ven!").Wait();
 
             doneHandlingMessage.WaitOrDie(TimeSpan.FromMinutes(2));
 


### PR DESCRIPTION
Changed unit tests to use the Create/Start API's to stop them failing on the new checks in Rebus activator with latest code in Git mater.

---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.
