### PR TITLE
Delete v0 of receive index

### DIFF
--- a/Rebus.SqlServer/SqlServer/Transport/SqlServerTransport.cs
+++ b/Rebus.SqlServer/SqlServer/Transport/SqlServerTransport.cs
@@ -190,6 +190,16 @@ IF NOT EXISTS (SELECT 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = '{ta
 
 ----
 
+-- Drop the V0 Receive Index
+-- v0 index was (Priority, Visible, Expiration, Id)
+-- We can find this by looking for the index with priority as is_descending_key = 0
+IF EXISTS (SELECT 1 FROM sys.indexes I JOIN sys.index_columns IC ON I.object_id = OBJECT_ID('{tableName.QualifiedName}') AND I.name = '{receiveIndexName}' AND IC.object_id = I.object_id AND IC.index_id = I.index_id JOIN sys.columns C ON C.object_id = IC.object_id AND C.column_id = IC.column_id AND C.name = 'priority' and IC.is_descending_key = 0)
+BEGIN
+    DROP INDEX [{receiveIndexName}] ON {tableName.QualifiedName}
+END
+
+----
+
 IF NOT EXISTS (SELECT 1 FROM sys.indexes WHERE name = '{receiveIndexName}')
     CREATE NONCLUSTERED INDEX [{receiveIndexName}] ON {tableName.QualifiedName}
     (


### PR DESCRIPTION
The schema for the receive index for SqlServeTransport has been changed but it doesn't handle a update scenario like it does for SqlServerLeaseTransport
---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.
