### PR TITLE
Remove IsExternalInit class as it isn't used

### DIFF
--- a/Rebus.SqlServer/SqlServer/IsExternalInit.cs
+++ b/Rebus.SqlServer/SqlServer/IsExternalInit.cs
@@ -1,8 +1,0 @@
-﻿// ReSharper disable CheckNamespace
-// ReSharper disable UnusedMember.Global
-#pragma warning disable CS1591
-namespace System.Runtime.CompilerServices;
-
-public class IsExternalInit
-{
-}


### PR DESCRIPTION
I think this is causing some strange issues with Polysharp where it believe the class is already available, even though it isn't for other projects.

---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.
