### PR TITLE
Parameterise outbox updates to help prevent plan cache pollution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ _ReSharper.*
 _NCrunch_*
 *.user
 *.backup
+.idea
 
 # MS Guideline
 **/packages/*


### PR DESCRIPTION
Addresses #113. Decided to serialize manually rather than using STJ / NewtonSoft as it seemed overkill to use one of those serialisers. Grateful for any comments / recommendations you have :)

---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.
