### PR TITLE
Added Outbox-opions to support interval settings and disabling forwarder

### DIFF
--- a/Rebus.SqlServer.Tests/Outbox/TestOutbox_Options.cs
+++ b/Rebus.SqlServer.Tests/Outbox/TestOutbox_Options.cs
@@ -1,0 +1,162 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Data.SqlClient;
+using NUnit.Framework;
+using Rebus.Activation;
+using Rebus.Bus;
+using Rebus.Config;
+using Rebus.Config.Outbox;
+using Rebus.Routing;
+using Rebus.Routing.TypeBased;
+using Rebus.Tests.Contracts;
+using Rebus.Transport;
+using Rebus.Transport.InMem;
+
+// ReSharper disable ArgumentsStyleLiteral
+// ReSharper disable AccessToDisposedClosure
+#pragma warning disable CS1998
+
+namespace Rebus.SqlServer.Tests.Outbox;
+
+[TestFixture]
+public class TestOutbox_Options : FixtureBase
+{
+    static string ConnectionString => SqlTestHelper.ConnectionString;
+
+    InMemNetwork _network;
+
+    protected override void SetUp()
+    {
+        base.SetUp();
+        SqlTestHelper.DropTable("RebusOutbox");
+        _network = new InMemNetwork();
+    }
+
+    record SomeMessage;
+
+    [Test]
+    public void DefaultOptionsAreCorrect()
+    {
+        var options = new OutboxOptions();
+        Assert.That(options.ForwarderIntervalSeconds, Is.EqualTo(1));
+        Assert.That(options.RunForwarder, Is.True);
+    }
+
+    [Test]
+    public void ThrowsWhenForwarderIntervalIsLessThanOneSecond()
+    {
+        var options = new OutboxOptions();
+        Assert.Throws<ArgumentOutOfRangeException>(() => options.ForwarderIntervalSeconds = 0);
+        Assert.Throws<ArgumentOutOfRangeException>(() => options.ForwarderIntervalSeconds = -1);
+    }
+
+    [Test]
+    public async Task DoesNotForwardMessagesWhenOutboxForwarderIsDisabled()
+    {
+        var settings = new FlakySenderTransportDecoratorSettings();
+
+        using var messageWasReceived = new ManualResetEvent(initialState: false);
+        using var server = CreateConsumer("server", a => a.Handle<SomeMessage>(async _ => messageWasReceived.Set()));
+        using var client = CreateOneWayClientWithRunForwarderFalse(r => r.TypeBased().Map<SomeMessage>("server"), settings);
+
+        // Keep success rate 0 for the client's direct send, forcing it to use the outbox.
+        settings.SuccessRate = 0;
+
+        await using (var connection = new SqlConnection(ConnectionString))
+        {
+            await connection.OpenAsync();
+            await using var transaction = connection.BeginTransaction();
+
+            using var scope = new RebusTransactionScope();
+            scope.UseOutbox(connection, transaction);
+            await client.Send(new SomeMessage());
+            await scope.CompleteAsync();
+            await transaction.CommitAsync();
+        }
+
+        // Even after we restore direct transport success rate, the outbox forwarder is NOT running,
+        // so the pending outbox message should NOT be sent.
+        settings.SuccessRate = 1;
+
+        // Wait a few seconds to verify the message is NOT received.
+        var messageReceived = messageWasReceived.WaitOne(TimeSpan.FromSeconds(5));
+        Assert.That(messageReceived, Is.False, "Message should NOT have been forwarded from outbox because RunForwarder is false.");
+    }
+
+    [Test]
+    public async Task ForwardsMessagesWhenOutboxForwarderIsEnabled()
+    {
+        var settings = new FlakySenderTransportDecoratorSettings();
+
+        using var messageWasReceived = new ManualResetEvent(initialState: false);
+        using var server = CreateConsumer("server", a => a.Handle<SomeMessage>(async _ => messageWasReceived.Set()));
+        using var client = CreateOneWayClientWithRunForwarderTrue(r => r.TypeBased().Map<SomeMessage>("server"), settings);
+
+        // Keep success rate 0 for the client's direct send, forcing it to use the outbox.
+        settings.SuccessRate = 0;
+
+        await using (var connection = new SqlConnection(ConnectionString))
+        {
+            await connection.OpenAsync();
+            await using var transaction = connection.BeginTransaction();
+
+            using var scope = new RebusTransactionScope();
+            scope.UseOutbox(connection, transaction);
+            await client.Send(new SomeMessage());
+            await scope.CompleteAsync();
+            await transaction.CommitAsync();
+        }
+
+        // Once we restore direct transport success rate, the outbox forwarder is running,
+        // so it should pick up the message and send it.
+        settings.SuccessRate = 1;
+
+        var messageReceived = messageWasReceived.WaitOne(TimeSpan.FromSeconds(10));
+        Assert.That(messageReceived, Is.True, "Message should be forwarded from outbox when RunForwarder is true.");
+    }
+
+    IBus CreateConsumer(string queueName, Action<BuiltinHandlerActivator> handlers = null)
+    {
+        var activator = new BuiltinHandlerActivator();
+        handlers?.Invoke(activator);
+
+        Configure.With(activator)
+            .Transport(t => t.UseInMemoryTransport(_network, queueName))
+            .Start();
+
+        return activator.Bus;
+    }
+
+    IBus CreateOneWayClientWithRunForwarderFalse(Action<StandardConfigurer<IRouter>> routing, FlakySenderTransportDecoratorSettings settings)
+    {
+        return Configure.With(new BuiltinHandlerActivator())
+            .Transport(t =>
+            {
+                t.UseInMemoryTransportAsOneWayClient(_network);
+                t.Decorate(c => new FlakySenderTransportDecorator(c.Get<ITransport>(), settings));
+            })
+            .Routing(r => routing?.Invoke(r))
+            .Outbox(
+                o => o.StoreInSqlServer(ConnectionString, "RebusOutbox"),
+                new OutboxOptions { RunForwarder = false }
+            )
+            .Start();
+    }
+
+    IBus CreateOneWayClientWithRunForwarderTrue(Action<StandardConfigurer<IRouter>> routing, FlakySenderTransportDecoratorSettings settings)
+    {
+        return Configure.With(new BuiltinHandlerActivator())
+            .Transport(t =>
+            {
+                t.UseInMemoryTransportAsOneWayClient(_network);
+                t.Decorate(c => new FlakySenderTransportDecorator(c.Get<ITransport>(), settings));
+            })
+            .Routing(r => routing?.Invoke(r))
+            .Outbox(
+                o => o.StoreInSqlServer(ConnectionString, "RebusOutbox"),
+                new OutboxOptions { RunForwarder = true, ForwarderIntervalSeconds = 1 }
+            )
+            .Start();
+    }
+}

--- a/Rebus.SqlServer/Config/Outbox/OutboxOptions.cs
+++ b/Rebus.SqlServer/Config/Outbox/OutboxOptions.cs
@@ -1,0 +1,32 @@
+﻿using System;
+
+namespace Rebus.Config.Outbox;
+
+/// <summary>
+/// Contains configuration options for the outbox
+/// </summary>
+public class OutboxOptions
+{
+    int _forwarderIntervalSeconds = 1;
+
+    /// <summary>
+    /// Gets or sets the interval in seconds between outbox forwarding runs. Default is 1. Cannot be less than 1.
+    /// </summary>
+    public int ForwarderIntervalSeconds
+    {
+        get => _forwarderIntervalSeconds;
+        set
+        {
+            if (value < 1)
+            {
+                throw new ArgumentOutOfRangeException(nameof(value), value, "The forwarder interval must be at least 1 second.");
+            }
+            _forwarderIntervalSeconds = value;
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets whether to run the outbox forwarder background task. Default is true.
+    /// </summary>
+    public bool RunForwarder { get; set; } = true;
+}

--- a/Rebus.SqlServer/Config/Outbox/SqlServerOutboxConfigurationExtensions.cs
+++ b/Rebus.SqlServer/Config/Outbox/SqlServerOutboxConfigurationExtensions.cs
@@ -20,8 +20,19 @@ public static class SqlServerOutboxConfigurationExtensions
     /// </summary>
     public static RebusConfigurer Outbox(this RebusConfigurer configurer, Action<StandardConfigurer<IOutboxStorage>> configure)
     {
+        return Outbox(configurer, configure, new OutboxOptions());
+    }
+
+    /// <summary>
+    /// Configures Rebus to use an outbox with the specified options.
+    /// This will store a (message ID, source queue) tuple for all processed messages, and under this tuple any messages sent/published will
+    /// also be stored, thus enabling truly idempotent message processing.
+    /// </summary>
+    public static RebusConfigurer Outbox(this RebusConfigurer configurer, Action<StandardConfigurer<IOutboxStorage>> configure, OutboxOptions options)
+    {
         if (configurer == null) throw new ArgumentNullException(nameof(configurer));
         if (configure == null) throw new ArgumentNullException(nameof(configure));
+        if (options == null) throw new ArgumentNullException(nameof(options));
 
         configurer.Options(o =>
         {
@@ -32,20 +43,23 @@ public static class SqlServerOutboxConfigurationExtensions
 
             o.Decorate<ITransport>(c => new OutboxClientTransportDecorator(c.Get<ITransport>(), c.Get<IOutboxStorage>()));
 
-            o.Register(c =>
+            if (options.RunForwarder)
             {
-                var asyncTaskFactory = c.Get<IAsyncTaskFactory>();
-                var rebusLoggerFactory = c.Get<IRebusLoggerFactory>();
-                var outboxStorage = c.Get<IOutboxStorage>();
-                var transport = c.Get<ITransport>();
-                return new OutboxForwarder(asyncTaskFactory, rebusLoggerFactory, outboxStorage, transport);
-            });
+                o.Register(c =>
+                {
+                    var asyncTaskFactory = c.Get<IAsyncTaskFactory>();
+                    var rebusLoggerFactory = c.Get<IRebusLoggerFactory>();
+                    var outboxStorage = c.Get<IOutboxStorage>();
+                    var transport = c.Get<ITransport>();
+                    return new OutboxForwarder(asyncTaskFactory, rebusLoggerFactory, outboxStorage, transport, options.ForwarderIntervalSeconds);
+                });
 
-            o.Decorate(c =>
-            {
-                _ = c.Get<OutboxForwarder>();
-                return c.Get<Options>();
-            });
+                o.Decorate(c =>
+                {
+                    _ = c.Get<OutboxForwarder>();
+                    return c.Get<Options>();
+                });
+            }
 
             o.Decorate<IPipeline>(c =>
             {

--- a/Rebus.SqlServer/SqlServer/Outbox/OutboxForwarder.cs
+++ b/Rebus.SqlServer/SqlServer/Outbox/OutboxForwarder.cs
@@ -39,11 +39,16 @@ class OutboxForwarder : IDisposable, IInitializable
     readonly ILog _logger;
 
     public OutboxForwarder(IAsyncTaskFactory asyncTaskFactory, IRebusLoggerFactory rebusLoggerFactory, IOutboxStorage outboxStorage, ITransport transport)
+        : this(asyncTaskFactory, rebusLoggerFactory, outboxStorage, transport, 1)
+    {
+    }
+
+    public OutboxForwarder(IAsyncTaskFactory asyncTaskFactory, IRebusLoggerFactory rebusLoggerFactory, IOutboxStorage outboxStorage, ITransport transport, int forwarderIntervalSeconds)
     {
         if (asyncTaskFactory == null) throw new ArgumentNullException(nameof(asyncTaskFactory));
         _outboxStorage = outboxStorage;
         _transport = transport;
-        _forwarder = asyncTaskFactory.Create("OutboxForwarder", RunForwarder, intervalSeconds: 1);
+        _forwarder = asyncTaskFactory.Create("OutboxForwarder", RunForwarder, intervalSeconds: forwarderIntervalSeconds);
         _cleaner = asyncTaskFactory.Create("OutboxCleaner", RunCleaner, intervalSeconds: 120);
         _logger = rebusLoggerFactory.GetLogger<OutboxForwarder>();
     }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-image: Visual Studio 2022
+image: Visual Studio 2026
 
 services:
   - mssql2017

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
 image: Visual Studio 2026
 
 services:
-  - mssql2017
+  - mssql2019
 
 shallow_clone: true
 


### PR DESCRIPTION
We have multiple rebus instances but to avoid polling from each of these, only one is elected to become the forwarder, even though multiple instances can send to the outbox. Therefore, optional support for NOT running the forwarder while still allowing outbox on send.

I have implemented support for issue #111 at the same time.



---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.
